### PR TITLE
Separate live and restart configure paths

### DIFF
--- a/server/cmd/api/api/chromium_configure.go
+++ b/server/cmd/api/api/chromium_configure.go
@@ -50,7 +50,7 @@ func (st *chromiumConfigureState) cleanup() {
 }
 
 // ChromiumConfigure batched Chromium/session configuration plus optional navigation.
-func (s *ApiService) ChromiumConfigure(ctx context.Context, request oapi.ChromiumConfigureRequestObject) (resp oapi.ChromiumConfigureResponseObject, err error) {
+func (s *ApiService) ChromiumConfigure(ctx context.Context, request oapi.ChromiumConfigureRequestObject) (oapi.ChromiumConfigureResponseObject, error) {
 	start := time.Now()
 
 	if request.Body == nil {
@@ -80,7 +80,60 @@ func (s *ApiService) ChromiumConfigure(ctx context.Context, request oapi.Chromiu
 	s.chromiumConfigMu.Lock()
 	defer s.chromiumConfigMu.Unlock()
 
-	needsStop := chromiumNeedsStopCycle(st)
+	var configureResp oapi.ChromiumConfigureResponseObject
+	switch chromiumConfigureModeFor(st) {
+	case chromiumConfigureModeLive:
+		configureResp = s.chromiumConfigureLive(ctx, st)
+	case chromiumConfigureModeRestart:
+		configureResp = s.chromiumConfigureRestart(ctx, st, spec)
+	}
+	if configureResp != nil {
+		return configureResp, nil
+	}
+
+	if spec.needsNav {
+		if err := chromiumDoNavigate(ctx, s, spec); err != nil {
+			logger.FromContext(ctx).Warn("start_url dispatch failed", "error", err)
+		}
+	}
+
+	logger.FromContext(ctx).Info("chromium configure finished", "elapsed", time.Since(start).String())
+	return oapi.ChromiumConfigure200JSONResponse{Ok: true}, nil
+}
+
+type chromiumConfigureMode uint8
+
+const (
+	chromiumConfigureModeLive chromiumConfigureMode = iota
+	chromiumConfigureModeRestart
+)
+
+func chromiumConfigureModeFor(st *chromiumConfigureState) chromiumConfigureMode {
+	if st.hasProfile ||
+		len(st.extItems) > 0 ||
+		policiesContentNonEmpty(st.chromePoliciesJSON) ||
+		flagsContentNonEmpty(st.chromiumFlagsJSON) {
+		return chromiumConfigureModeRestart
+	}
+	return chromiumConfigureModeLive
+}
+
+func (s *ApiService) chromiumConfigureLive(ctx context.Context, st *chromiumConfigureState) oapi.ChromiumConfigureResponseObject {
+	if st.displayJSON == nil || strings.TrimSpace(*st.displayJSON) == "" {
+		return nil
+	}
+
+	displayPlan, displayResp := chromiumPrepareDisplay(ctx, s, st.displayJSON)
+	if displayResp != nil {
+		return displayResp
+	}
+	if displayPlan == nil {
+		return nil
+	}
+	return chromiumRunPatchDisplay(ctx, s, displayPlan.body)
+}
+
+func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumConfigureState, spec startURLParsed) (resp oapi.ChromiumConfigureResponseObject) {
 	chromiumStopped := false
 	restartAfterStop := func() error {
 		if !chromiumStopped {
@@ -99,103 +152,80 @@ func (s *ApiService) ChromiumConfigure(ctx context.Context, request oapi.Chromiu
 				return
 			}
 			resp = cfg500ConfigureStep(chromiumConfigureStepStart, restartErr.Error())
-			err = nil
 		}
 	}()
 
-	if needsStop {
-		logger.FromContext(ctx).Info("chromium configure (stop/start path)")
-		if err := s.stopChromium(ctx); err != nil {
-			return cfg500ConfigureStep(chromiumConfigureStepStop, err.Error()), nil
-		}
-		chromiumStopped = true
+	logger.FromContext(ctx).Info("chromium configure (stop/start path)")
+	if err := s.stopChromium(ctx); err != nil {
+		return cfg500ConfigureStep(chromiumConfigureStepStop, err.Error())
+	}
+	chromiumStopped = true
 
-		policyOverrides, err := chromiumValidatePolicies(st.chromePoliciesJSON)
-		if err != nil {
-			return cfgResponseFromStepError(chromiumConfigureStepPolicies, err), nil
-		}
-		if err := chromiumApplyPolicies(ctx, s, policyOverrides); err != nil {
-			return cfgResponseFromStepError(chromiumConfigureStepPolicies, err), nil
-		}
+	policyOverrides, err := chromiumValidatePolicies(st.chromePoliciesJSON)
+	if err != nil {
+		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err)
+	}
+	if err := chromiumApplyPolicies(ctx, s, policyOverrides); err != nil {
+		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err)
+	}
 
-		if reqMsgs, ierr := chromiumApplyExtensions(ctx, s, st.extItems); reqMsgs != "" {
-			return cfg400(fmt.Sprintf("%s: %s", chromiumConfigureStepExtensions, reqMsgs)), nil
-		} else if ierr != nil {
-			return cfg500ConfigureStep(chromiumConfigureStepExtensions, ierr.Error()), nil
-		}
+	if reqMsgs, ierr := chromiumApplyExtensions(ctx, s, st.extItems); reqMsgs != "" {
+		return cfg400(fmt.Sprintf("%s: %s", chromiumConfigureStepExtensions, reqMsgs))
+	} else if ierr != nil {
+		return cfg500ConfigureStep(chromiumConfigureStepExtensions, ierr.Error())
+	}
 
-		if st.displayJSON != nil && strings.TrimSpace(*st.displayJSON) != "" {
-			displayPlan, displayResp := chromiumPrepareDisplay(ctx, s, st.displayJSON)
-			if displayResp != nil {
-				return displayResp, nil
-			}
-			if displayPlan != nil {
-				stopped, stopErr := s.stopActiveRecordings(ctx)
-				if stopErr != nil {
-					return cfg500ConfigureStep(chromiumConfigureStepDisplay, fmt.Sprintf("failed to stop recordings: %v", stopErr)), nil
-				}
-				if len(stopped) > 0 {
-					defer func() {
-						go s.startNewRecordingSegments(context.WithoutCancel(ctx), stopped)
-					}()
-				}
-				if rr := chromiumDisplayApplyWhileStopped(ctx, s, displayPlan); rr != nil {
-					return rr, nil
-				}
-			}
+	if st.displayJSON != nil && strings.TrimSpace(*st.displayJSON) != "" {
+		displayPlan, displayResp := chromiumPrepareDisplay(ctx, s, st.displayJSON)
+		if displayResp != nil {
+			return displayResp
 		}
-
-		flagsPlan, err := chromiumValidateFlags(st.chromiumFlagsJSON)
-		if err != nil {
-			return cfgResponseFromStepError(chromiumConfigureStepFlags, err), nil
-		}
-		if err := chromiumMergeFlags(ctx, s, flagsPlan); err != nil {
-			return cfgResponseFromStepError(chromiumConfigureStepFlags, err), nil
-		}
-
-		if st.hasProfile {
-			preparedProfile, cleanupProfile, err := chromiumPrepareProfileArchive(st.profileTemp, st.stripComponents)
-			if cleanupProfile != nil {
-				defer cleanupProfile()
+		if displayPlan != nil {
+			stopped, stopErr := s.stopActiveRecordings(ctx)
+			if stopErr != nil {
+				return cfg500ConfigureStep(chromiumConfigureStepDisplay, fmt.Sprintf("failed to stop recordings: %v", stopErr))
 			}
-			if err != nil {
-				return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), nil
+			if len(stopped) > 0 {
+				defer func() {
+					go s.startNewRecordingSegments(context.WithoutCancel(ctx), stopped)
+				}()
 			}
-			if spec.needsNav {
-				if err := stripProfileSessionRestore(preparedProfile); err != nil {
-					return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), nil
-				}
-			}
-			if err := chromiumInstallPreparedProfile(preparedProfile); err != nil {
-				return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), nil
-			}
-		}
-
-		if err := restartAfterStop(); err != nil {
-			return cfg500ConfigureStep(chromiumConfigureStepStart, err.Error()), nil
-		}
-	} else {
-		if st.displayJSON != nil && strings.TrimSpace(*st.displayJSON) != "" {
-			displayPlan, displayResp := chromiumPrepareDisplay(ctx, s, st.displayJSON)
-			if displayResp != nil {
-				return displayResp, nil
-			}
-			if displayPlan != nil {
-				if rr := chromiumRunPatchDisplay(ctx, s, displayPlan.body); rr != nil {
-					return rr, nil
-				}
+			if rr := chromiumDisplayApplyWhileStopped(ctx, s, displayPlan); rr != nil {
+				return rr
 			}
 		}
 	}
 
-	if spec.needsNav {
-		if err := chromiumDoNavigate(ctx, s, spec); err != nil {
-			logger.FromContext(ctx).Warn("start_url dispatch failed", "error", err)
+	flagsPlan, err := chromiumValidateFlags(st.chromiumFlagsJSON)
+	if err != nil {
+		return cfgResponseFromStepError(chromiumConfigureStepFlags, err)
+	}
+	if err := chromiumMergeFlags(ctx, s, flagsPlan); err != nil {
+		return cfgResponseFromStepError(chromiumConfigureStepFlags, err)
+	}
+
+	if st.hasProfile {
+		preparedProfile, cleanupProfile, err := chromiumPrepareProfileArchive(st.profileTemp, st.stripComponents)
+		if cleanupProfile != nil {
+			defer cleanupProfile()
+		}
+		if err != nil {
+			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error())
+		}
+		if spec.needsNav {
+			if err := stripProfileSessionRestore(preparedProfile); err != nil {
+				return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error())
+			}
+		}
+		if err := chromiumInstallPreparedProfile(preparedProfile); err != nil {
+			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error())
 		}
 	}
 
-	logger.FromContext(ctx).Info("chromium configure finished", "elapsed", time.Since(start).String())
-	return oapi.ChromiumConfigure200JSONResponse{Ok: true}, nil
+	if err := restartAfterStop(); err != nil {
+		return cfg500ConfigureStep(chromiumConfigureStepStart, err.Error())
+	}
+	return nil
 }
 
 type startURLParsed struct {
@@ -298,13 +328,6 @@ type chromiumDisplayPlan struct {
 	width       int
 	height      int
 	refreshRate int
-}
-
-func chromiumNeedsStopCycle(st *chromiumConfigureState) bool {
-	return st.hasProfile ||
-		len(st.extItems) > 0 ||
-		policiesContentNonEmpty(st.chromePoliciesJSON) ||
-		flagsContentNonEmpty(st.chromiumFlagsJSON)
 }
 
 func policiesContentNonEmpty(s *string) bool {

--- a/server/cmd/api/api/chromium_configure.go
+++ b/server/cmd/api/api/chromium_configure.go
@@ -81,28 +81,16 @@ func (s *ApiService) ChromiumConfigure(ctx context.Context, request oapi.Chromiu
 	defer s.chromiumConfigMu.Unlock()
 
 	var configureResp oapi.ChromiumConfigureResponseObject
-	var stoppedRecordings []stoppedRecordingInfo
 	switch chromiumConfigureModeFor(st) {
 	case chromiumConfigureModeLive:
-		configureResp = s.chromiumConfigureLive(ctx, st)
+		configureResp = s.chromiumConfigureLive(ctx, st, spec)
 	case chromiumConfigureModeRestart:
-		configureResp, stoppedRecordings = s.chromiumConfigureRestart(ctx, st, spec)
+		configureResp = s.chromiumConfigureRestart(ctx, st, spec)
 	default:
 		return cfg500Configure("unhandled configure mode"), nil
 	}
-	if len(stoppedRecordings) > 0 {
-		defer func() {
-			go s.startNewRecordingSegments(context.WithoutCancel(ctx), stoppedRecordings)
-		}()
-	}
 	if configureResp != nil {
 		return configureResp, nil
-	}
-
-	if spec.needsNav {
-		if err := chromiumDoNavigate(ctx, s, spec); err != nil {
-			logger.FromContext(ctx).Warn("start_url dispatch failed", "error", err)
-		}
 	}
 
 	logger.FromContext(ctx).Info("chromium configure finished", "elapsed", time.Since(start).String())
@@ -126,22 +114,34 @@ func chromiumConfigureModeFor(st *chromiumConfigureState) chromiumConfigureMode 
 	return chromiumConfigureModeLive
 }
 
-func (s *ApiService) chromiumConfigureLive(ctx context.Context, st *chromiumConfigureState) oapi.ChromiumConfigureResponseObject {
-	if st.displayJSON == nil || strings.TrimSpace(*st.displayJSON) == "" {
-		return nil
+func (s *ApiService) chromiumConfigureLive(ctx context.Context, st *chromiumConfigureState, spec startURLParsed) oapi.ChromiumConfigureResponseObject {
+	if st.displayJSON != nil && strings.TrimSpace(*st.displayJSON) != "" {
+		displayPlan, displayResp := chromiumPrepareDisplay(ctx, s, st.displayJSON)
+		if displayResp != nil {
+			return displayResp
+		}
+		if displayPlan != nil {
+			if resp := chromiumRunPatchDisplay(ctx, s, displayPlan.body); resp != nil {
+				return resp
+			}
+		}
 	}
 
-	displayPlan, displayResp := chromiumPrepareDisplay(ctx, s, st.displayJSON)
-	if displayResp != nil {
-		return displayResp
-	}
-	if displayPlan == nil {
-		return nil
-	}
-	return chromiumRunPatchDisplay(ctx, s, displayPlan.body)
+	chromiumConfigureNavigate(ctx, s, spec)
+	return nil
 }
 
-func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumConfigureState, spec startURLParsed) (resp oapi.ChromiumConfigureResponseObject, stoppedRecordings []stoppedRecordingInfo) {
+func chromiumConfigureNavigate(ctx context.Context, s *ApiService, spec startURLParsed) {
+	if !spec.needsNav {
+		return
+	}
+	if err := chromiumDoNavigate(ctx, s, spec); err != nil {
+		logger.FromContext(ctx).Warn("start_url dispatch failed", "error", err)
+	}
+}
+
+func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumConfigureState, spec startURLParsed) (resp oapi.ChromiumConfigureResponseObject) {
+	var stoppedRecordings []stoppedRecordingInfo
 	chromiumStopped := false
 	restartAfterStop := func() error {
 		if !chromiumStopped {
@@ -154,8 +154,8 @@ func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumC
 		return nil
 	}
 	defer func() {
-		// Error paths restart recordings before Chromium recovery. Successful paths
-		// return them so the caller waits until after navigation.
+		// Error paths restart recordings before Chromium recovery. chromiumStopped
+		// also covers a panic before the explicit restart below.
 		if (resp != nil || chromiumStopped) && len(stoppedRecordings) > 0 {
 			go s.startNewRecordingSegments(context.WithoutCancel(ctx), stoppedRecordings)
 			stoppedRecordings = nil
@@ -171,47 +171,47 @@ func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumC
 
 	logger.FromContext(ctx).Info("chromium configure (stop/start path)")
 	if err := s.stopChromium(ctx); err != nil {
-		return cfg500ConfigureStep(chromiumConfigureStepStop, err.Error()), stoppedRecordings
+		return cfg500ConfigureStep(chromiumConfigureStepStop, err.Error())
 	}
 	chromiumStopped = true
 
 	policyOverrides, err := chromiumValidatePolicies(st.chromePoliciesJSON)
 	if err != nil {
-		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err), stoppedRecordings
+		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err)
 	}
 	if err := chromiumApplyPolicies(ctx, s, policyOverrides); err != nil {
-		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err), stoppedRecordings
+		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err)
 	}
 
 	if reqMsgs, ierr := chromiumApplyExtensions(ctx, s, st.extItems); reqMsgs != "" {
-		return cfg400(fmt.Sprintf("%s: %s", chromiumConfigureStepExtensions, reqMsgs)), stoppedRecordings
+		return cfg400(fmt.Sprintf("%s: %s", chromiumConfigureStepExtensions, reqMsgs))
 	} else if ierr != nil {
-		return cfg500ConfigureStep(chromiumConfigureStepExtensions, ierr.Error()), stoppedRecordings
+		return cfg500ConfigureStep(chromiumConfigureStepExtensions, ierr.Error())
 	}
 
 	if st.displayJSON != nil && strings.TrimSpace(*st.displayJSON) != "" {
 		displayPlan, displayResp := chromiumPrepareDisplay(ctx, s, st.displayJSON)
 		if displayResp != nil {
-			return displayResp, stoppedRecordings
+			return displayResp
 		}
 		if displayPlan != nil {
 			stopped, stopErr := s.stopActiveRecordings(ctx)
 			if stopErr != nil {
-				return cfg500ConfigureStep(chromiumConfigureStepDisplay, fmt.Sprintf("failed to stop recordings: %v", stopErr)), stoppedRecordings
+				return cfg500ConfigureStep(chromiumConfigureStepDisplay, fmt.Sprintf("failed to stop recordings: %v", stopErr))
 			}
 			stoppedRecordings = stopped
 			if rr := chromiumDisplayApplyWhileStopped(ctx, s, displayPlan); rr != nil {
-				return rr, stoppedRecordings
+				return rr
 			}
 		}
 	}
 
 	flagsPlan, err := chromiumValidateFlags(st.chromiumFlagsJSON)
 	if err != nil {
-		return cfgResponseFromStepError(chromiumConfigureStepFlags, err), stoppedRecordings
+		return cfgResponseFromStepError(chromiumConfigureStepFlags, err)
 	}
 	if err := chromiumMergeFlags(ctx, s, flagsPlan); err != nil {
-		return cfgResponseFromStepError(chromiumConfigureStepFlags, err), stoppedRecordings
+		return cfgResponseFromStepError(chromiumConfigureStepFlags, err)
 	}
 
 	if st.hasProfile {
@@ -220,22 +220,27 @@ func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumC
 			defer cleanupProfile()
 		}
 		if err != nil {
-			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), stoppedRecordings
+			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error())
 		}
 		if spec.needsNav {
 			if err := stripProfileSessionRestore(preparedProfile); err != nil {
-				return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), stoppedRecordings
+				return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error())
 			}
 		}
 		if err := chromiumInstallPreparedProfile(preparedProfile); err != nil {
-			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), stoppedRecordings
+			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error())
 		}
 	}
 
 	if err := restartAfterStop(); err != nil {
-		return cfg500ConfigureStep(chromiumConfigureStepStart, err.Error()), stoppedRecordings
+		return cfg500ConfigureStep(chromiumConfigureStepStart, err.Error())
 	}
-	return nil, stoppedRecordings
+	chromiumConfigureNavigate(ctx, s, spec)
+	if len(stoppedRecordings) > 0 {
+		go s.startNewRecordingSegments(context.WithoutCancel(ctx), stoppedRecordings)
+		stoppedRecordings = nil
+	}
+	return nil
 }
 
 type startURLParsed struct {

--- a/server/cmd/api/api/chromium_configure.go
+++ b/server/cmd/api/api/chromium_configure.go
@@ -81,11 +81,19 @@ func (s *ApiService) ChromiumConfigure(ctx context.Context, request oapi.Chromiu
 	defer s.chromiumConfigMu.Unlock()
 
 	var configureResp oapi.ChromiumConfigureResponseObject
+	var stoppedRecordings []stoppedRecordingInfo
 	switch chromiumConfigureModeFor(st) {
 	case chromiumConfigureModeLive:
 		configureResp = s.chromiumConfigureLive(ctx, st)
 	case chromiumConfigureModeRestart:
-		configureResp = s.chromiumConfigureRestart(ctx, st, spec)
+		configureResp, stoppedRecordings = s.chromiumConfigureRestart(ctx, st, spec)
+	default:
+		return cfg500Configure("unhandled configure mode"), nil
+	}
+	if len(stoppedRecordings) > 0 {
+		defer func() {
+			go s.startNewRecordingSegments(context.WithoutCancel(ctx), stoppedRecordings)
+		}()
 	}
 	if configureResp != nil {
 		return configureResp, nil
@@ -133,7 +141,7 @@ func (s *ApiService) chromiumConfigureLive(ctx context.Context, st *chromiumConf
 	return chromiumRunPatchDisplay(ctx, s, displayPlan.body)
 }
 
-func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumConfigureState, spec startURLParsed) (resp oapi.ChromiumConfigureResponseObject) {
+func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumConfigureState, spec startURLParsed) (resp oapi.ChromiumConfigureResponseObject, stoppedRecordings []stoppedRecordingInfo) {
 	chromiumStopped := false
 	restartAfterStop := func() error {
 		if !chromiumStopped {
@@ -146,6 +154,12 @@ func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumC
 		return nil
 	}
 	defer func() {
+		// Error paths restart recordings before Chromium recovery. Successful paths
+		// return them so the caller waits until after navigation.
+		if (resp != nil || chromiumStopped) && len(stoppedRecordings) > 0 {
+			go s.startNewRecordingSegments(context.WithoutCancel(ctx), stoppedRecordings)
+			stoppedRecordings = nil
+		}
 		if restartErr := restartAfterStop(); restartErr != nil {
 			if resp != nil {
 				logger.FromContext(ctx).Error("failed to restart chromium after configure error", "error", restartErr)
@@ -157,51 +171,47 @@ func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumC
 
 	logger.FromContext(ctx).Info("chromium configure (stop/start path)")
 	if err := s.stopChromium(ctx); err != nil {
-		return cfg500ConfigureStep(chromiumConfigureStepStop, err.Error())
+		return cfg500ConfigureStep(chromiumConfigureStepStop, err.Error()), stoppedRecordings
 	}
 	chromiumStopped = true
 
 	policyOverrides, err := chromiumValidatePolicies(st.chromePoliciesJSON)
 	if err != nil {
-		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err)
+		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err), stoppedRecordings
 	}
 	if err := chromiumApplyPolicies(ctx, s, policyOverrides); err != nil {
-		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err)
+		return cfgResponseFromStepError(chromiumConfigureStepPolicies, err), stoppedRecordings
 	}
 
 	if reqMsgs, ierr := chromiumApplyExtensions(ctx, s, st.extItems); reqMsgs != "" {
-		return cfg400(fmt.Sprintf("%s: %s", chromiumConfigureStepExtensions, reqMsgs))
+		return cfg400(fmt.Sprintf("%s: %s", chromiumConfigureStepExtensions, reqMsgs)), stoppedRecordings
 	} else if ierr != nil {
-		return cfg500ConfigureStep(chromiumConfigureStepExtensions, ierr.Error())
+		return cfg500ConfigureStep(chromiumConfigureStepExtensions, ierr.Error()), stoppedRecordings
 	}
 
 	if st.displayJSON != nil && strings.TrimSpace(*st.displayJSON) != "" {
 		displayPlan, displayResp := chromiumPrepareDisplay(ctx, s, st.displayJSON)
 		if displayResp != nil {
-			return displayResp
+			return displayResp, stoppedRecordings
 		}
 		if displayPlan != nil {
 			stopped, stopErr := s.stopActiveRecordings(ctx)
 			if stopErr != nil {
-				return cfg500ConfigureStep(chromiumConfigureStepDisplay, fmt.Sprintf("failed to stop recordings: %v", stopErr))
+				return cfg500ConfigureStep(chromiumConfigureStepDisplay, fmt.Sprintf("failed to stop recordings: %v", stopErr)), stoppedRecordings
 			}
-			if len(stopped) > 0 {
-				defer func() {
-					go s.startNewRecordingSegments(context.WithoutCancel(ctx), stopped)
-				}()
-			}
+			stoppedRecordings = stopped
 			if rr := chromiumDisplayApplyWhileStopped(ctx, s, displayPlan); rr != nil {
-				return rr
+				return rr, stoppedRecordings
 			}
 		}
 	}
 
 	flagsPlan, err := chromiumValidateFlags(st.chromiumFlagsJSON)
 	if err != nil {
-		return cfgResponseFromStepError(chromiumConfigureStepFlags, err)
+		return cfgResponseFromStepError(chromiumConfigureStepFlags, err), stoppedRecordings
 	}
 	if err := chromiumMergeFlags(ctx, s, flagsPlan); err != nil {
-		return cfgResponseFromStepError(chromiumConfigureStepFlags, err)
+		return cfgResponseFromStepError(chromiumConfigureStepFlags, err), stoppedRecordings
 	}
 
 	if st.hasProfile {
@@ -210,22 +220,22 @@ func (s *ApiService) chromiumConfigureRestart(ctx context.Context, st *chromiumC
 			defer cleanupProfile()
 		}
 		if err != nil {
-			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error())
+			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), stoppedRecordings
 		}
 		if spec.needsNav {
 			if err := stripProfileSessionRestore(preparedProfile); err != nil {
-				return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error())
+				return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), stoppedRecordings
 			}
 		}
 		if err := chromiumInstallPreparedProfile(preparedProfile); err != nil {
-			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error())
+			return cfg500ConfigureStep(chromiumConfigureStepProfile, err.Error()), stoppedRecordings
 		}
 	}
 
 	if err := restartAfterStop(); err != nil {
-		return cfg500ConfigureStep(chromiumConfigureStepStart, err.Error())
+		return cfg500ConfigureStep(chromiumConfigureStepStart, err.Error()), stoppedRecordings
 	}
-	return nil
+	return nil, stoppedRecordings
 }
 
 type startURLParsed struct {

--- a/server/cmd/api/api/chromium_configure_test.go
+++ b/server/cmd/api/api/chromium_configure_test.go
@@ -29,30 +29,33 @@ func TestPoliciesContentNonEmpty(t *testing.T) {
 	require.True(t, policiesContentNonEmpty(&real))
 }
 
-func TestChromiumConfigureActionableFlags(t *testing.T) {
-	emptyFlags := `{"flags":[]}`
-	realFlags := `{"flags":["--kiosk"]}`
+func TestChromiumConfigureModeFor(t *testing.T) {
+	stringPtr := func(value string) *string { return &value }
 
-	st := &chromiumConfigureState{chromiumFlagsJSON: &emptyFlags}
-	require.Equal(t, 0, cfgActionables(st))
-	require.False(t, chromiumNeedsStopCycle(st))
+	tests := []struct {
+		name  string
+		state chromiumConfigureState
+		want  chromiumConfigureMode
+	}{
+		{name: "no restart fields", want: chromiumConfigureModeLive},
+		{name: "display only", state: chromiumConfigureState{displayJSON: stringPtr(`{"width":1280}`)}, want: chromiumConfigureModeLive},
+		{name: "start URL only", state: chromiumConfigureState{startURLRaw: stringPtr("https://example.com")}, want: chromiumConfigureModeLive},
+		{name: "empty policies", state: chromiumConfigureState{chromePoliciesJSON: stringPtr(`{}`)}, want: chromiumConfigureModeLive},
+		{name: "nonempty policies", state: chromiumConfigureState{chromePoliciesJSON: stringPtr(`{"QuicAllowed":false}`)}, want: chromiumConfigureModeRestart},
+		{name: "invalid policies", state: chromiumConfigureState{chromePoliciesJSON: stringPtr(`{bad-json`)}, want: chromiumConfigureModeRestart},
+		{name: "empty flags", state: chromiumConfigureState{chromiumFlagsJSON: stringPtr(`{"flags":[]}`)}, want: chromiumConfigureModeLive},
+		{name: "nonempty flags", state: chromiumConfigureState{chromiumFlagsJSON: stringPtr(`{"flags":["--kiosk"]}`)}, want: chromiumConfigureModeRestart},
+		{name: "invalid flags", state: chromiumConfigureState{chromiumFlagsJSON: stringPtr(`{bad-json`)}, want: chromiumConfigureModeRestart},
+		{name: "profile", state: chromiumConfigureState{hasProfile: true}, want: chromiumConfigureModeRestart},
+		{name: "extensions", state: chromiumConfigureState{extItems: []extensionZipItem{{name: "test"}}}, want: chromiumConfigureModeRestart},
+		{name: "display and extension", state: chromiumConfigureState{displayJSON: stringPtr(`{"width":1280}`), extItems: []extensionZipItem{{name: "test"}}}, want: chromiumConfigureModeRestart},
+	}
 
-	st = &chromiumConfigureState{chromiumFlagsJSON: &realFlags}
-	require.Equal(t, 1, cfgActionables(st))
-	require.True(t, chromiumNeedsStopCycle(st))
-}
-
-func TestChromiumConfigureActionablePolicies(t *testing.T) {
-	emptyPolicies := `{}`
-	realPolicies := `{"QuicAllowed":false}`
-
-	st := &chromiumConfigureState{chromePoliciesJSON: &emptyPolicies}
-	require.Equal(t, 0, cfgActionables(st))
-	require.False(t, chromiumNeedsStopCycle(st))
-
-	st = &chromiumConfigureState{chromePoliciesJSON: &realPolicies}
-	require.Equal(t, 1, cfgActionables(st))
-	require.True(t, chromiumNeedsStopCycle(st))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, chromiumConfigureModeFor(&tt.state))
+		})
+	}
 }
 
 func TestChromiumStartURLSpec(t *testing.T) {

--- a/server/cmd/api/api/chromium_configure_test.go
+++ b/server/cmd/api/api/chromium_configure_test.go
@@ -58,6 +58,30 @@ func TestChromiumConfigureModeFor(t *testing.T) {
 	}
 }
 
+func TestChromiumConfigureActionables(t *testing.T) {
+	emptyFlags := `{"flags":[]}`
+	realFlags := `{"flags":["--kiosk"]}`
+	emptyPolicies := `{}`
+	realPolicies := `{"QuicAllowed":false}`
+
+	tests := []struct {
+		name  string
+		state chromiumConfigureState
+		want  int
+	}{
+		{name: "empty flags", state: chromiumConfigureState{chromiumFlagsJSON: &emptyFlags}},
+		{name: "nonempty flags", state: chromiumConfigureState{chromiumFlagsJSON: &realFlags}, want: 1},
+		{name: "empty policies", state: chromiumConfigureState{chromePoliciesJSON: &emptyPolicies}},
+		{name: "nonempty policies", state: chromiumConfigureState{chromePoliciesJSON: &realPolicies}, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, cfgActionables(&tt.state))
+		})
+	}
+}
+
 func TestChromiumStartURLSpec(t *testing.T) {
 	bareHost := "roblox.com"
 	out, errs := chromiumStartURLSpec(&bareHost)

--- a/server/e2e/e2e_chromium_configure_powerset_test.go
+++ b/server/e2e/e2e_chromium_configure_powerset_test.go
@@ -44,6 +44,7 @@ func TestChromiumConfigureMultipartPowerset(t *testing.T) {
 
 	matrix := []int{
 		matDisplay,
+		matStartURL,
 		matPolicy | matKioskFlags,
 		matExtension,
 		matDisplay | matPolicy | matKioskFlags | matExtension | matStartURL,
@@ -73,6 +74,9 @@ func TestChromiumConfigureMultipartPowerset(t *testing.T) {
 			defer func() { _ = c.Stop(context.WithoutCancel(ctx)) }()
 
 			require.NoError(t, c.WaitReady(ctx))
+			require.NoError(t, c.WaitDevTools(ctx))
+			browserWebSocketBefore, err := fetchBrowserWebSocketURL(ctx, c)
+			require.NoError(t, err)
 
 			var body bytes.Buffer
 			w := multipart.NewWriter(&body)
@@ -89,8 +93,20 @@ func TestChromiumConfigureMultipartPowerset(t *testing.T) {
 				"bits=%02x unexpected status=%s body=%s", bits, rsp.Status(), string(rsp.Body))
 			require.NotNil(t, rsp.JSON200, "want ok JSON")
 			require.True(t, rsp.JSON200.Ok)
+
+			browserWebSocketAfter, err := fetchBrowserWebSocketURL(ctx, c)
+			require.NoError(t, err)
+			if chromiumConfigurePowersetRestarts(bits) {
+				require.NotEqual(t, browserWebSocketBefore, browserWebSocketAfter, "restart path must replace the browser WebSocket identity")
+			} else {
+				require.Equal(t, browserWebSocketBefore, browserWebSocketAfter, "live path must preserve the browser WebSocket identity")
+			}
 		})
 	}
+}
+
+func chromiumConfigurePowersetRestarts(bits int) bool {
+	return bits&(matPolicy|matKioskFlags|matExtension) != 0
 }
 
 func chromiumConfigurePowersetLabel(bits int) string {

--- a/server/e2e/e2e_chromium_configure_powerset_test.go
+++ b/server/e2e/e2e_chromium_configure_powerset_test.go
@@ -106,6 +106,7 @@ func TestChromiumConfigureMultipartPowerset(t *testing.T) {
 }
 
 func chromiumConfigurePowersetRestarts(bits int) bool {
+	// This matrix runs against headless Xvfb, where display-only configure stays live.
 	return bits&(matPolicy|matKioskFlags|matExtension) != 0
 }
 


### PR DESCRIPTION
## Summary

- model `/chromium/configure` as explicit live and restart execution modes
- extract clearly named helpers for the existing live display path and stop/start path without changing their ordering or error handling
- preserve restart selection for profiles, extensions, nonempty policies, and nonempty Chromium flags
- preserve live behavior for display-only and `start_url`-only requests
- preserve recording-segment restart ordering after successful navigation and before Chromium recovery on error paths
- add mode/actionable-selection unit coverage and browser WebSocket identity assertions for live and restart e2e cases

## Testing

- `go vet ./...`
- `go test -race ./cmd/api/api -count=1`
- `go test -v -race -timeout 15m ./e2e -run '^TestChromiumConfigureMultipartPowerset$' -count=1`
- built `images/chromium-headless/image/Dockerfile` locally for the e2e run

The full non-e2e race suite was also attempted. All packages passed except the existing `lib/devtoolsproxy` restart test, which failed during `t.TempDir` cleanup because Chromium was still writing its profile directory; rerunning that package reproduced the same cleanup failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Chromium lifecycle, display/recording coordination, and configure error recovery—behavior-preserving refactor but operationally sensitive.
> 
> **Overview**
> **`/chromium/configure`** is refactored around explicit **live** vs **restart** execution modes instead of a single inline `needsStop` branch.
> 
> `ChromiumConfigure` dispatches via `chromiumConfigureModeFor` (replacing `chromiumNeedsStopCycle`) into `chromiumConfigureLive` (display patch + optional `start_url` without stopping Chromium) and `chromiumConfigureRestart` (stop/apply/start). Shared navigation moves to `chromiumConfigureNavigate`.
> 
> On the restart path, **recording segment resume** is centralized: segments restart after successful navigation on the happy path, and in a `defer` on errors (before Chromium recovery) instead of only via a display-step `defer`.
> 
> Unit tests cover mode selection and actionables; the configure powerset e2e adds `start_url` cases and asserts browser WebSocket identity is preserved on live configures and changes on policy/flags/extension restart paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7753a246f73936a18c101e537fee2aa9f0da711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->