### PR TITLE
Add Noto Mono to browser images

### DIFF
--- a/images/chromium-headful/Dockerfile
+++ b/images/chromium-headful/Dockerfile
@@ -213,6 +213,7 @@ RUN apt-get update && \
     fonts-noto-cjk \
     fonts-noto-color-emoji \
     fonts-noto-core \
+    fonts-noto-mono \
     fonts-nanum \
     fonts-dejavu-core \
     fonts-dejavu-extra \

--- a/images/chromium-headless/image/Dockerfile
+++ b/images/chromium-headless/image/Dockerfile
@@ -158,6 +158,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=$CACHEIDPREFIX-ap
     fontconfig \
     fonts-noto-cjk \
     fonts-noto-color-emoji \
+    fonts-noto-mono \
     fonts-nanum \
     supervisor; \
     fc-cache -f


### PR DESCRIPTION
## Summary

Add the `fonts-noto-mono` package to both headful and headless browser images. The existing font-cache build step picks it up during image construction.

This fills a Linux font-family gap that fingerprint consistency checks can identify even when the rest of the browser fingerprint is coherent.

## Testing

- `docker run --rm ubuntu:22.04 ... apt-get install fonts-noto-mono ... fc-match "Noto Mono"` → `NotoMono-Regular.ttf: "Noto Mono" "Regular"`
- `cd server && GOCACHE=/tmp/kernel-images-go-cache GOMODCACHE=/tmp/kernel-images-go-mod make test-unit`
- validated the same package in a running browser image; rebuilding the font cache changed the fingerprint verdict from masking detected to no masking detected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standard apt font package to Docker images with no auth, runtime, or data-handling changes. Image rebuilds will include a slightly larger font set.
> 
> **Overview**
> Installs `fonts-noto-mono` in both headful and headless Chromium images so the font cache includes Noto Mono.
> 
> This closes a Linux font-family gap that fingerprint consistency checks can flag even when the rest of the browser fingerprint looks coherent. Existing `fc-cache` steps pick the package up at image build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e669afadc37175c98b28fc06d11b17f695f39ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->