### PR TITLE
Handle Playwright active tabs across contexts

### DIFF
--- a/server/e2e/e2e_playwright_test.go
+++ b/server/e2e/e2e_playwright_test.go
@@ -142,6 +142,33 @@ func TestPlaywrightExecuteAPI(t *testing.T) {
 	require.Contains(t, refocusedUrlRsp.JSON200.Result, "example.com", "expected injected page to follow foreground focus, not tab-creation order")
 
 	t.Log("playwright foreground-tab binding test passed")
+
+	t.Log("verifying page resolution across browser contexts")
+	openSecondContextRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
+		Code: `
+			const secondContext = await browser.newContext();
+			const secondPage = await secondContext.newPage();
+			await secondPage.goto('data:text/html,second-context');
+			await secondPage.bringToFront();
+			return browser.contexts().length;
+		`,
+	})
+	require.NoError(t, err, "open second context request error: %v", err)
+	require.Equal(t, http.StatusOK, openSecondContextRsp.StatusCode(), "unexpected status: %s body=%s", openSecondContextRsp.Status(), string(openSecondContextRsp.Body))
+	require.NotNil(t, openSecondContextRsp.JSON200)
+	require.True(t, openSecondContextRsp.JSON200.Success, "expected open-second-context success=true")
+	require.EqualValues(t, 2, openSecondContextRsp.JSON200.Result, "expected two browser contexts")
+
+	for i := 0; i < 30; i++ {
+		crossContextRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
+			Code: `return page.context() === context && browser.contexts().length === 2;`,
+		})
+		require.NoError(t, err, "cross-context request %d error: %v", i+1, err)
+		require.Equal(t, http.StatusOK, crossContextRsp.StatusCode(), "cross-context request %d returned %s body=%s", i+1, crossContextRsp.Status(), string(crossContextRsp.Body))
+		require.NotNil(t, crossContextRsp.JSON200)
+		require.True(t, crossContextRsp.JSON200.Success, "cross-context request %d failed", i+1)
+		require.Equal(t, true, crossContextRsp.JSON200.Result, "cross-context request %d injected a mismatched page and context", i+1)
+	}
 }
 
 func TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers(t *testing.T) {

--- a/server/e2e/e2e_playwright_test.go
+++ b/server/e2e/e2e_playwright_test.go
@@ -144,35 +144,51 @@ func TestPlaywrightExecuteAPI(t *testing.T) {
 	t.Log("playwright foreground-tab binding test passed")
 
 	t.Log("verifying page resolution across browser contexts")
-	// Leave a newer page behind the foreground page so the newest-open-page
-	// fallback cannot satisfy the active-tab assertion.
 	openSecondContextRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
 		Code: `
+			const firstContext = browser.contexts()[0];
 			const secondContext = await browser.newContext();
 			const secondPage = await secondContext.newPage();
 			await secondPage.goto('data:text/html,second-context');
-			const fallbackPage = await secondContext.newPage();
-			await fallbackPage.goto('data:text/html,fallback-page');
-			await secondPage.bringToFront();
-			return browser.contexts().length;
+			await Promise.all(firstContext.pages().map(page => page.close()));
+			return {
+				contextCount: browser.contexts().length,
+				firstContextPageCount: firstContext.pages().length,
+			};
 		`,
 	})
 	require.NoError(t, err, "open second context request error: %v", err)
 	require.Equal(t, http.StatusOK, openSecondContextRsp.StatusCode(), "unexpected status: %s body=%s", openSecondContextRsp.Status(), string(openSecondContextRsp.Body))
 	require.NotNil(t, openSecondContextRsp.JSON200)
 	require.True(t, openSecondContextRsp.JSON200.Success, "expected open-second-context success=true")
-	require.EqualValues(t, 2, openSecondContextRsp.JSON200.Result, "expected two browser contexts")
 
-	for i := 0; i < 30; i++ {
-		crossContextRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
-			Code: `return page.url();`,
-		})
-		require.NoError(t, err, "cross-context request %d error: %v", i+1, err)
-		require.Equal(t, http.StatusOK, crossContextRsp.StatusCode(), "cross-context request %d returned %s body=%s", i+1, crossContextRsp.Status(), string(crossContextRsp.Body))
-		require.NotNil(t, crossContextRsp.JSON200)
-		require.True(t, crossContextRsp.JSON200.Success, "cross-context request %d failed", i+1)
-		require.Equal(t, "data:text/html,second-context", crossContextRsp.JSON200.Result, "cross-context request %d injected the fallback page instead of the foreground page", i+1)
+	setupResultBytes, err := json.Marshal(openSecondContextRsp.JSON200.Result)
+	require.NoError(t, err)
+	var setupResult struct {
+		ContextCount          int `json:"contextCount"`
+		FirstContextPageCount int `json:"firstContextPageCount"`
 	}
+	require.NoError(t, json.Unmarshal(setupResultBytes, &setupResult))
+	require.Equal(t, 2, setupResult.ContextCount, "expected two browser contexts")
+	require.Zero(t, setupResult.FirstContextPageCount, "expected the first context to remain open without pages")
+
+	crossContextRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
+		Code: `return { url: page.url(), contextIndex: browser.contexts().indexOf(page.context()) };`,
+	})
+	require.NoError(t, err, "cross-context request error: %v", err)
+	require.Equal(t, http.StatusOK, crossContextRsp.StatusCode(), "cross-context request returned %s body=%s", crossContextRsp.Status(), string(crossContextRsp.Body))
+	require.NotNil(t, crossContextRsp.JSON200)
+	require.True(t, crossContextRsp.JSON200.Success, "cross-context request failed")
+
+	resultBytes, err = json.Marshal(crossContextRsp.JSON200.Result)
+	require.NoError(t, err)
+	var crossContextResult struct {
+		URL          string `json:"url"`
+		ContextIndex int    `json:"contextIndex"`
+	}
+	require.NoError(t, json.Unmarshal(resultBytes, &crossContextResult))
+	require.Equal(t, "data:text/html,second-context", crossContextResult.URL, "expected page from the second context")
+	require.Equal(t, 1, crossContextResult.ContextIndex, "expected page context at index 1")
 }
 
 func TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers(t *testing.T) {

--- a/server/e2e/e2e_playwright_test.go
+++ b/server/e2e/e2e_playwright_test.go
@@ -144,16 +144,21 @@ func TestPlaywrightExecuteAPI(t *testing.T) {
 	t.Log("playwright foreground-tab binding test passed")
 
 	t.Log("verifying page resolution across browser contexts")
+	// Keep a newer blank page behind the foreground page so the newest-page
+	// fallback cannot satisfy the active-page assertion.
 	openSecondContextRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
 		Code: `
 			const firstContext = browser.contexts()[0];
 			const secondContext = await browser.newContext();
 			const secondPage = await secondContext.newPage();
 			await secondPage.goto('data:text/html,second-context');
+			await secondContext.newPage();
 			await Promise.all(firstContext.pages().map(page => page.close()));
+			await secondPage.bringToFront();
 			return {
 				contextCount: browser.contexts().length,
 				firstContextPageCount: firstContext.pages().length,
+				secondContextPageCount: secondContext.pages().length,
 			};
 		`,
 	})
@@ -165,15 +170,17 @@ func TestPlaywrightExecuteAPI(t *testing.T) {
 	setupResultBytes, err := json.Marshal(openSecondContextRsp.JSON200.Result)
 	require.NoError(t, err)
 	var setupResult struct {
-		ContextCount          int `json:"contextCount"`
-		FirstContextPageCount int `json:"firstContextPageCount"`
+		ContextCount           int `json:"contextCount"`
+		FirstContextPageCount  int `json:"firstContextPageCount"`
+		SecondContextPageCount int `json:"secondContextPageCount"`
 	}
 	require.NoError(t, json.Unmarshal(setupResultBytes, &setupResult))
 	require.Equal(t, 2, setupResult.ContextCount, "expected two browser contexts")
 	require.Zero(t, setupResult.FirstContextPageCount, "expected the first context to remain open without pages")
+	require.Equal(t, 2, setupResult.SecondContextPageCount, "expected a foreground page and a newer fallback page in the second context")
 
 	crossContextRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
-		Code: `return { url: page.url(), contextIndex: browser.contexts().indexOf(page.context()) };`,
+		Code: `return { url: page.url(), contextPageUrls: page.context().pages().map(candidate => candidate.url()) };`,
 	})
 	require.NoError(t, err, "cross-context request error: %v", err)
 	require.Equal(t, http.StatusOK, crossContextRsp.StatusCode(), "cross-context request returned %s body=%s", crossContextRsp.Status(), string(crossContextRsp.Body))
@@ -183,12 +190,12 @@ func TestPlaywrightExecuteAPI(t *testing.T) {
 	resultBytes, err = json.Marshal(crossContextRsp.JSON200.Result)
 	require.NoError(t, err)
 	var crossContextResult struct {
-		URL          string `json:"url"`
-		ContextIndex int    `json:"contextIndex"`
+		URL             string   `json:"url"`
+		ContextPageURLs []string `json:"contextPageUrls"`
 	}
 	require.NoError(t, json.Unmarshal(resultBytes, &crossContextResult))
-	require.Equal(t, "data:text/html,second-context", crossContextResult.URL, "expected page from the second context")
-	require.Equal(t, 1, crossContextResult.ContextIndex, "expected page context at index 1")
+	require.Equal(t, "data:text/html,second-context", crossContextResult.URL, "expected active-page resolution to select the foreground page, not the newer fallback page")
+	require.ElementsMatch(t, []string{"data:text/html,second-context", "about:blank"}, crossContextResult.ContextPageURLs, "expected the selected page to belong to the second context")
 }
 
 func TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers(t *testing.T) {

--- a/server/e2e/e2e_playwright_test.go
+++ b/server/e2e/e2e_playwright_test.go
@@ -144,11 +144,15 @@ func TestPlaywrightExecuteAPI(t *testing.T) {
 	t.Log("playwright foreground-tab binding test passed")
 
 	t.Log("verifying page resolution across browser contexts")
+	// Leave a newer page behind the foreground page so the newest-open-page
+	// fallback cannot satisfy the active-tab assertion.
 	openSecondContextRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
 		Code: `
 			const secondContext = await browser.newContext();
 			const secondPage = await secondContext.newPage();
 			await secondPage.goto('data:text/html,second-context');
+			const fallbackPage = await secondContext.newPage();
+			await fallbackPage.goto('data:text/html,fallback-page');
 			await secondPage.bringToFront();
 			return browser.contexts().length;
 		`,
@@ -161,13 +165,13 @@ func TestPlaywrightExecuteAPI(t *testing.T) {
 
 	for i := 0; i < 30; i++ {
 		crossContextRsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
-			Code: `return page.context() === context && browser.contexts().length === 2;`,
+			Code: `return page.url();`,
 		})
 		require.NoError(t, err, "cross-context request %d error: %v", i+1, err)
 		require.Equal(t, http.StatusOK, crossContextRsp.StatusCode(), "cross-context request %d returned %s body=%s", i+1, crossContextRsp.Status(), string(crossContextRsp.Body))
 		require.NotNil(t, crossContextRsp.JSON200)
 		require.True(t, crossContextRsp.JSON200.Success, "cross-context request %d failed", i+1)
-		require.Equal(t, true, crossContextRsp.JSON200.Result, "cross-context request %d injected a mismatched page and context", i+1)
+		require.Equal(t, "data:text/html,second-context", crossContextRsp.JSON200.Result, "cross-context request %d injected the fallback page instead of the foreground page", i+1)
 	}
 }
 

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1366,8 +1366,9 @@ paths:
 
         'page' is bound to an active tab reported by Chrome. In single-window sessions, this is
         the foreground tab. When multiple browser windows are open, Chrome reports one active tab
-        per window and the selected window is unspecified. Use 'context.pages()' to select a page
-        explicitly.
+        per window and the selected window is unspecified. 'context' is the BrowserContext that owns
+        the selected page. If active-tab resolution races with a target change, execution falls back
+        to an existing page. Use 'browser.contexts()' to select a context or page explicitly.
       operationId: executePlaywrightCode
       x-telemetry-category: control
       requestBody:

--- a/server/runtime/playwright-daemon.ts
+++ b/server/runtime/playwright-daemon.ts
@@ -189,8 +189,10 @@ async function pageForTabTarget(browser: Browser, targetId: string, pages: Page[
 
 // Chrome reports one active tab per window. Try every reported target against
 // every Playwright context, then retry once in case focus changed mid-lookup.
+const ACTIVE_PAGE_RESOLUTION_ATTEMPTS = 2;
+
 async function resolveActivePage(browser: Browser): Promise<Page | null> {
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < ACTIVE_PAGE_RESOLUTION_ATTEMPTS; attempt++) {
     try {
       const pages = browser
         .contexts()
@@ -201,10 +203,16 @@ async function resolveActivePage(browser: Browser): Promise<Page | null> {
         try {
           const page = await pageForTabTarget(browser, targetId, pages);
           if (page) return page;
-        } catch {}
+        } catch {
+          // This tab may have changed while it was inspected. Keep trying the
+          // other active tabs reported by the same browser snapshot.
+        }
       }
+
+      // No active tab matched this page snapshot. Retry with fresh snapshots.
     } catch {
-      // Fall back after the retry if Chrome changes targets during resolution.
+      // The browser-wide lookup raced with a target change. Discard this pass;
+      // the next attempt, if any, snapshots both pages and active tabs again.
     }
   }
 

--- a/server/runtime/playwright-daemon.ts
+++ b/server/runtime/playwright-daemon.ts
@@ -12,7 +12,7 @@
 import { createServer, Socket } from 'net';
 import { unlinkSync, existsSync } from 'fs';
 import { transform } from 'esbuild';
-import { chromium as chromiumPW, Browser, BrowserContext, Page } from 'playwright-core';
+import { chromium as chromiumPW, Browser, Page } from 'playwright-core';
 import { chromium as chromiumPR } from 'patchright';
 
 const SOCKET_PATH = process.env.PLAYWRIGHT_DAEMON_SOCKET || '/tmp/playwright-daemon.sock';
@@ -131,13 +131,7 @@ async function ensureBrowserConnection(): Promise<Browser> {
   }
 }
 
-// Resolves the browser's actual foreground tab via CDP rather than guessing from
-// tab-creation order. Chrome 150+ populates `TargetInfo.embedderData.tabActive`
-// on `tab` targets from the real tab strip state; the Playwright `Page` for that
-// tab is found by relating the tab target to its page target with
-// `Target.autoAttachRelated`. Every session used here is temporary and detached
-// before returning, so this adds no cross-request state to the daemon.
-async function resolveActivePage(browser: Browser, context: BrowserContext): Promise<Page> {
+async function activeTabTargetIds(browser: Browser): Promise<string[]> {
   const root = await browser.newBrowserCDPSession();
 
   try {
@@ -145,9 +139,18 @@ async function resolveActivePage(browser: Browser, context: BrowserContext): Pro
       filter: [{ type: 'tab', exclude: false }, { exclude: true }],
     });
 
-    const activeTab = targetInfos.find(target => (target.embedderData as any)?.tabActive === true);
-    if (!activeTab) throw new Error('no foreground tab reported by CDP');
+    return targetInfos
+      .filter(target => (target.embedderData as any)?.tabActive === true)
+      .map(target => target.targetId);
+  } finally {
+    await root.detach().catch(() => {});
+  }
+}
 
+async function pageForTabTarget(browser: Browser, targetId: string, pages: Page[]): Promise<Page | null> {
+  const root = await browser.newBrowserCDPSession();
+
+  try {
     const relatedPageIds = new Set<string>();
     root.on('Target.attachedToTarget', event => {
       if (event.targetInfo.type === 'page' && !event.targetInfo.subtype) {
@@ -156,13 +159,14 @@ async function resolveActivePage(browser: Browser, context: BrowserContext): Pro
     });
 
     await root.send('Target.autoAttachRelated', {
-      targetId: activeTab.targetId,
+      targetId,
       waitForDebuggerOnStart: false,
       filter: [{ type: 'page', exclude: false }, { exclude: true }],
     });
 
-    for (const page of context.pages()) {
+    for (const page of pages) {
       try {
+        const context = page.context();
         const session = await context.newCDPSession(page);
         try {
           const { targetInfo } = await session.send('Target.getTargetInfo');
@@ -177,10 +181,34 @@ async function resolveActivePage(browser: Browser, context: BrowserContext): Pro
       }
     }
 
-    throw new Error('foreground tab has no matching Playwright page');
+    return null;
   } finally {
     await root.detach().catch(() => {});
   }
+}
+
+// Chrome reports one active tab per window. Try every reported target against
+// every Playwright context, then retry once in case focus changed mid-lookup.
+async function resolveActivePage(browser: Browser): Promise<Page | null> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const pages = browser
+        .contexts()
+        .flatMap(context => context.pages())
+        .filter(page => !page.isClosed());
+
+      for (const targetId of await activeTabTargetIds(browser)) {
+        try {
+          const page = await pageForTabTarget(browser, targetId, pages);
+          if (page) return page;
+        } catch {}
+      }
+    } catch {
+      // Fall back after the retry if Chrome changes targets during resolution.
+    }
+  }
+
+  return null;
 }
 
 async function executeCode(request: ExecuteRequest, signal: AbortSignal): Promise<ExecuteResponse> {
@@ -222,13 +250,17 @@ async function executeCode(request: ExecuteRequest, signal: AbortSignal): Promis
       }
     }
     const contexts = browserInstance.contexts();
-    const context = contexts.length > 0 ? contexts[0] : await browserInstance.newContext();
-    const pages = context.pages();
+    const defaultContext = contexts.length > 0 ? contexts[0] : await browserInstance.newContext();
+    const pages = contexts.flatMap(context => context.pages());
     // Bind `page` to the actual foreground tab (see resolveActivePage). Using
     // pages[0] bound `page` to the oldest tab regardless of which was active, so
     // calls like page.pdf() operated on the wrong tab whenever more than one was
     // open.
-    const page = pages.length > 0 ? await resolveActivePage(browserInstance, context) : await context.newPage();
+    const page =
+      (pages.length > 0 ? await resolveActivePage(browserInstance) : null) ??
+      pages.findLast(candidate => !candidate.isClosed()) ??
+      (await defaultContext.newPage());
+    const context = page.context();
 
     const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
     const userFunction = new AsyncFunction('page', 'context', 'browser', jsCode);

--- a/server/runtime/playwright-daemon.ts
+++ b/server/runtime/playwright-daemon.ts
@@ -208,6 +208,7 @@ async function resolveActivePage(browser: Browser): Promise<Page | null> {
     }
   }
 
+  console.error('[playwright-daemon] active-tab resolution failed; falling back');
   return null;
 }
 

--- a/server/runtime/playwright-daemon.ts
+++ b/server/runtime/playwright-daemon.ts
@@ -188,18 +188,36 @@ async function pageForTabTarget(browser: Browser, targetId: string, pages: Page[
 }
 
 // Chrome reports one active tab per window. Try every reported target against
-// every Playwright context, then retry once in case focus changed mid-lookup.
-const ACTIVE_PAGE_RESOLUTION_ATTEMPTS = 2;
+// every Playwright context's pages.
+//
+// A pass can legitimately find an active tab with no matching page. The known
+// cause is a cross-origin navigation in a freshly opened tab (e.g. a site
+// handing the user off to a sibling product on another origin): Chrome swaps
+// the tab's page target to a new renderer process and marks the tab active
+// before Playwright has attached to the replacement target. That gap is
+// transient but has been observed to outlast back-to-back daemon calls, so an
+// immediate retry lands inside the same gap; the retries are spaced to give
+// Playwright time to attach. The delay is only paid when a pass fails, and
+// callers fall back to an open page if every attempt misses.
+const ACTIVE_PAGE_RESOLUTION_ATTEMPTS = 3;
+const ACTIVE_PAGE_RESOLUTION_RETRY_DELAY_MS = 150;
 
 async function resolveActivePage(browser: Browser): Promise<Page | null> {
+  let activeTabIds: string[] = [];
+
   for (let attempt = 0; attempt < ACTIVE_PAGE_RESOLUTION_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await new Promise(resolve => setTimeout(resolve, ACTIVE_PAGE_RESOLUTION_RETRY_DELAY_MS));
+    }
+
     try {
       const pages = browser
         .contexts()
         .flatMap(context => context.pages())
         .filter(page => !page.isClosed());
 
-      for (const targetId of await activeTabTargetIds(browser)) {
+      activeTabIds = await activeTabTargetIds(browser);
+      for (const targetId of activeTabIds) {
         try {
           const page = await pageForTabTarget(browser, targetId, pages);
           if (page) return page;
@@ -216,7 +234,10 @@ async function resolveActivePage(browser: Browser): Promise<Page | null> {
     }
   }
 
-  console.error('[playwright-daemon] active-tab resolution failed; falling back');
+  console.error(
+    `[playwright-daemon] active-tab resolution failed after ${ACTIVE_PAGE_RESOLUTION_ATTEMPTS} attempts; ` +
+      `falling back (unmatched active tabs: ${activeTabIds.join(', ') || 'none reported'})`,
+  );
   return null;
 }
 


### PR DESCRIPTION
## Summary

- resolve Chrome's active tab against pages from every Playwright browser context
- inject the selected page's owning context, retry target lookup once, and fall back to an open page instead of failing execution
- add cross-context regression coverage and document the selection/fallback behavior

## Validation

- rebuilt the daemon with the affected image's compiler, hotpatched it through the browser File API, and restarted Chromium
- reproduced the original cross-context failure on the baseline bundle
- passed 30/30 consecutive patched cycles; every cycle recreated and foregrounded a second context before a fresh daemon probe
- verified same-context focus still selects a newly opened tab and then an older refocused tab
- `go vet ./e2e/...`
- non-e2e race suite passed except for one transient `devtoolsproxy` temp-directory cleanup failure; the focused rerun passed
- the container e2e target could not start because its local test image was unavailable; no test logic ran
- CI passed the headful/headless image builds, server unit suite, packaged-image e2e suite, and static/security checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tab and context arbitrary Playwright code runs against, with retry/fallback semantics that could mask transient CDP mismatches but reduce hard failures in multi-context sessions.
> 
> **Overview**
> **Playwright execute** now picks Chrome’s foreground tab by scanning **all** browser contexts’ pages (not only the first context), binds **`context`** to that page’s owning `BrowserContext`, and **retries** CDP active-tab lookup up to three times when targets race with navigation.
> 
> If active-tab resolution still fails, execution **no longer errors**—it falls back to the last open page or creates a new one in the default context. OpenAPI docs describe this selection and fallback behavior.
> 
> An **e2e regression** opens a second context with a foreground tab plus a newer blank “decoy” page and asserts injected `page` resolves to the foreground URL in that context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc43d97734712312dad5a124eabb165fe678404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->