### PR TITLE
Enable WebMCP by default and merge feature-list flags

### DIFF
--- a/images/chromium-headful/run-docker.sh
+++ b/images/chromium-headful/run-docker.sh
@@ -14,7 +14,7 @@ mkdir -p "$HOST_RECORDINGS_DIR"
 RUN_AS_ROOT="${RUN_AS_ROOT:-false}"
 
 # Build Chromium flags file and mount
-CHROMIUM_FLAGS_DEFAULT="--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=*"
+CHROMIUM_FLAGS_DEFAULT="--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --enable-features=WebMCPTesting,DevToolsWebMCPSupport"
 if [[ "$RUN_AS_ROOT" == "true" ]]; then
   CHROMIUM_FLAGS_DEFAULT="$CHROMIUM_FLAGS_DEFAULT --no-sandbox --no-zygote"
 fi

--- a/images/chromium-headful/run-unikernel.sh
+++ b/images/chromium-headful/run-unikernel.sh
@@ -20,7 +20,7 @@ volume_name="${NAME}-flags"
 # RUN_AS_ROOT defaults to true in unikernel (for now, until we figure it out)
 RUN_AS_ROOT="${RUN_AS_ROOT:-true}"
 
-chromium_flags_default="--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=*"
+chromium_flags_default="--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --enable-features=WebMCPTesting,DevToolsWebMCPSupport"
 if [[ "$RUN_AS_ROOT" == "true" ]]; then
   chromium_flags_default="$chromium_flags_default --no-sandbox --no-zygote"
 fi

--- a/server/cmd/api/api/chromium.go
+++ b/server/cmd/api/api/chromium.go
@@ -598,6 +598,9 @@ func (s *ApiService) mergeAndWriteChromiumFlags(ctx context.Context, newTokens [
 
 	// Merge existing flags with new flags using token-aware API
 	mergedTokens := chromiumflags.MergeFlags(existingTokens, newTokens)
+	// Fold kernel-namespaced disable tokens into the plain Chromium switch so
+	// /chromium/flags only ever holds switches Chromium understands.
+	mergedTokens = chromiumflags.TranslateKernelDisableFeatures(mergedTokens)
 
 	if err := writeChromiumFlags(mergedTokens); err != nil {
 		log.Error("failed to write flags", "error", err)

--- a/server/cmd/chromium-launcher/main.go
+++ b/server/cmd/chromium-launcher/main.go
@@ -81,6 +81,7 @@ func main() {
 		os.Exit(1)
 	}
 	final := chromiumflags.MergeFlagsWithRuntimeTokens(baseFlags, runtimeTokens)
+	final = chromiumflags.TranslateKernelDisableFeatures(final)
 	final = withDefaultPrivateNetworkBypass(final)
 
 	// Diagnostics for parity with previous scripts

--- a/server/cmd/wrapper/chromium.go
+++ b/server/cmd/wrapper/chromium.go
@@ -41,6 +41,11 @@ func applyHeadlessDefaultFlags() {
 		"--disable-renderer-backgrounding",
 		"--disable-search-engine-choice-screen",
 		"--disable-software-rasterizer",
+		// WebMCP (navigator.modelContext + CDP WebMCP domain, Chromium 151+).
+		// DevToolsWebMCPSupport is default-on upstream; listing it keeps the
+		// CDP domain stable against finch flips. Sessions can opt out per
+		// instance via --disable-features=WebMCPTesting,DevToolsWebMCPSupport.
+		"--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
 		"--enable-use-zoom-for-dsf=false",
 		"--export-tagged-pdf",
 		"--force-color-profile=srgb",

--- a/server/lib/chromiumflags/chromiumflags.go
+++ b/server/lib/chromiumflags/chromiumflags.go
@@ -86,10 +86,7 @@ func union(base, rt []string) []string {
 // (base/feature_list.cc), which terminates the name at the first of ':',
 // '.', or '<' — parameter, group, and study separators respectively.
 func canonicalEnableFeatureName(entry string) string {
-	if i := strings.IndexAny(entry, ":.<"); i >= 0 {
-		return entry[:i]
-	}
-	return entry
+	return stripLeadingStar(cutAtFirst(entry, ":.<"))
 }
 
 // canonicalDisableFeatureName strips decoration from a --disable-features
@@ -97,10 +94,22 @@ func canonicalEnableFeatureName(entry string) string {
 // RegisterOverridesFromCommandLine, which only splits on '<'; dots and colons
 // are part of the name.
 func canonicalDisableFeatureName(entry string) string {
-	if i := strings.IndexByte(entry, '<'); i >= 0 {
+	return stripLeadingStar(cutAtFirst(entry, "<"))
+}
+
+// cutAtFirst returns entry up to its first byte in separators, if any.
+func cutAtFirst(entry, separators string) string {
+	if i := strings.IndexAny(entry, separators); i >= 0 {
 		return entry[:i]
 	}
 	return entry
+}
+
+// stripLeadingStar removes the optional '*' default-reset prefix that
+// RegisterOverride consumes before inserting into its override map, so
+// *Foo and Foo collapse to one canonical key.
+func stripLeadingStar(name string) string {
+	return strings.TrimPrefix(name, "*")
 }
 
 // mergeFeatureEntries merges base and runtime feature-list entries into one

--- a/server/lib/chromiumflags/chromiumflags.go
+++ b/server/lib/chromiumflags/chromiumflags.go
@@ -36,10 +36,11 @@ func appendCSVInto(dst *[]string, csv string) {
 	}
 }
 
-// parseTokenStream extracts extension-related flags and collects non-extension flags.
-// It returns the list of non-extension tokens and, via references, fills the buckets for
-// --load-extension, --disable-extensions-except and a possible --disable-extensions token for that stream.
-func parseTokenStream(tokens []string, load, except *[]string, disableAll *string) (nonExt []string) {
+// parseTokenStream extracts extension-related and feature-list flags and collects the rest.
+// It returns the leftover tokens and, via references, fills the buckets for
+// --load-extension, --disable-extensions-except, --enable-features, --disable-features
+// and a possible --disable-extensions token for that stream.
+func parseTokenStream(tokens []string, load, except, enableFeatures, disableFeatures *[]string, disableAll *string) (nonExt []string) {
 	for _, tok := range tokens {
 		switch {
 		case strings.HasPrefix(tok, "--load-extension="):
@@ -48,6 +49,12 @@ func parseTokenStream(tokens []string, load, except *[]string, disableAll *strin
 		case strings.HasPrefix(tok, "--disable-extensions-except="):
 			val := strings.TrimPrefix(tok, "--disable-extensions-except=")
 			appendCSVInto(except, val)
+		case strings.HasPrefix(tok, "--enable-features="):
+			val := strings.TrimPrefix(tok, "--enable-features=")
+			appendCSVInto(enableFeatures, val)
+		case strings.HasPrefix(tok, "--disable-features="):
+			val := strings.TrimPrefix(tok, "--disable-features=")
+			appendCSVInto(disableFeatures, val)
 		case tok == "--disable-extensions":
 			*disableAll = tok
 		default:
@@ -128,28 +135,51 @@ func ReadOptionalFlagFile(path string) ([]string, error) {
 // extensions_enabled() returns true, which is false when --disable-extensions-except is used.
 // Any paths from --disable-extensions-except are merged into --load-extension instead.
 //
-// Non-extension flags from both base and runtime are combined with deduplication (first occurrence preserved).
+// Feature-list flags (--enable-features / --disable-features) from both sources are also
+// merged into single comma-separated tokens. Chromium keeps only one value per switch, so
+// emitting duplicates would silently drop all but the last list. When a feature appears in
+// both lists Chromium disables it — disable wins over enable.
+//
+// Non-feature, non-extension flags from both base and runtime are combined with deduplication
+// (first occurrence preserved).
 func MergeFlags(baseTokens, runtimeTokens []string) []string {
 	// Buckets
 	var (
-		baseNonExt     []string // Non-extension related flags contained in base
-		runtimeNonExt  []string // Non-extension related flags contained in runtime
-		baseLoad       []string // --load-extension flags contained in base
-		baseExcept     []string // --disable-extensions-except flags for base (parsed but not re-emitted)
-		rtLoad         []string // --load-extension flags contained in runtime
-		rtExcept       []string // --disable-extensions-except flags contained in runtime (parsed but not re-emitted)
-		baseDisableAll string   // --disable-extensions flag contained in base
-		rtDisableAll   string   // --disable-extensions flag contained in runtime
+		baseNonExt      []string // Non-extension related flags contained in base
+		runtimeNonExt   []string // Non-extension related flags contained in runtime
+		baseLoad        []string // --load-extension flags contained in base
+		baseExcept      []string // --disable-extensions-except flags for base (parsed but not re-emitted)
+		baseEnableFeat  []string // --enable-features values contained in base
+		baseDisableFeat []string // --disable-features values contained in base
+		rtLoad          []string // --load-extension flags contained in runtime
+		rtExcept        []string // --disable-extensions-except flags contained in runtime (parsed but not re-emitted)
+		rtEnableFeat    []string // --enable-features values contained in runtime
+		rtDisableFeat   []string // --disable-features values contained in runtime
+		baseDisableAll  string   // --disable-extensions flag contained in base
+		rtDisableAll    string   // --disable-extensions flag contained in runtime
 	)
 
-	baseNonExt = parseTokenStream(baseTokens, &baseLoad, &baseExcept, &baseDisableAll)
-	runtimeNonExt = parseTokenStream(runtimeTokens, &rtLoad, &rtExcept, &rtDisableAll)
+	baseNonExt = parseTokenStream(baseTokens, &baseLoad, &baseExcept, &baseEnableFeat, &baseDisableFeat, &baseDisableAll)
+	runtimeNonExt = parseTokenStream(runtimeTokens, &rtLoad, &rtExcept, &rtEnableFeat, &rtDisableFeat, &rtDisableAll)
 
 	// Merge extension lists - include paths from --disable-extensions-except in load paths
 	// since we no longer emit --disable-extensions-except
 	mergedLoad := union(baseLoad, rtLoad)
 	mergedLoad = union(mergedLoad, baseExcept)
 	mergedLoad = union(mergedLoad, rtExcept)
+
+	// Merge feature lists - a feature listed in both enable and disable stays in both;
+	// Chromium resolves that conflict as disabled.
+	mergedEnableFeat := union(baseEnableFeat, rtEnableFeat)
+	mergedDisableFeat := union(baseDisableFeat, rtDisableFeat)
+
+	var featureFlags []string
+	if len(mergedEnableFeat) > 0 {
+		featureFlags = append(featureFlags, "--enable-features="+strings.Join(mergedEnableFeat, ","))
+	}
+	if len(mergedDisableFeat) > 0 {
+		featureFlags = append(featureFlags, "--disable-features="+strings.Join(mergedDisableFeat, ","))
+	}
 
 	// Construct final extension-related flags respecting override semantics:
 	// 1) If runtime specifies --disable-extensions, it overrides everything extension related
@@ -169,6 +199,7 @@ func MergeFlags(baseTokens, runtimeTokens []string) []string {
 
 	// Combine and dedupe (preserving first occurrence)
 	combined := append(append([]string{}, baseNonExt...), runtimeNonExt...)
+	combined = append(combined, featureFlags...)
 	combined = append(combined, extFlags...)
 	seen := make(map[string]struct{}, len(combined))
 	final := make([]string, 0, len(combined))

--- a/server/lib/chromiumflags/chromiumflags.go
+++ b/server/lib/chromiumflags/chromiumflags.go
@@ -81,6 +81,46 @@ func union(base, rt []string) []string {
 	return out
 }
 
+// canonicalFeatureName strips trial/parameter decoration from a feature-list
+// entry. Entries may be of the form Feature or Feature<Trial (Chromium splits
+// on '<' and registers only the part before it as the feature name).
+func canonicalFeatureName(entry string) string {
+	if i := strings.IndexByte(entry, '<'); i >= 0 {
+		return entry[:i]
+	}
+	return entry
+}
+
+// mergeFeatureEntries merges base and runtime feature-list entries into one
+// list holding a single entry per canonical feature name, preserving first-
+// seen order. A runtime entry replaces a base entry with the same canonical
+// name, and later entries replace earlier ones within a stream.
+//
+// This matters because Chromium's FeatureList registers overrides keyed by
+// canonical name and keeps only the FIRST entry per name (try_emplace in
+// base/feature_list.cc RegisterOverride). Emitting two decorated variants of
+// one feature (e.g. base Foo<TrialA plus runtime Foo<TrialB) would therefore
+// let the base configuration silently win; collapsing here makes the emitted
+// switch carry exactly one deliberate configuration per feature.
+func mergeFeatureEntries(baseVals, rtVals []string) []string {
+	index := make(map[string]int, len(baseVals)+len(rtVals))
+	out := make([]string, 0, len(baseVals)+len(rtVals))
+	add := func(vals []string) {
+		for _, v := range vals {
+			name := canonicalFeatureName(v)
+			if pos, ok := index[name]; ok {
+				out[pos] = v
+				continue
+			}
+			index[name] = len(out)
+			out = append(out, v)
+		}
+	}
+	add(baseVals)
+	add(rtVals)
+	return out
+}
+
 // ReadOptionalFlagFile returns the flags array from the JSON file at path.
 // If the file does not exist, it returns nil and a nil error.
 func ReadOptionalFlagFile(path string) ([]string, error) {
@@ -168,10 +208,11 @@ func MergeFlags(baseTokens, runtimeTokens []string) []string {
 	mergedLoad = union(mergedLoad, baseExcept)
 	mergedLoad = union(mergedLoad, rtExcept)
 
-	// Merge feature lists - a feature listed in both enable and disable stays in both;
-	// Chromium resolves that conflict as disabled.
-	mergedEnableFeat := union(baseEnableFeat, rtEnableFeat)
-	mergedDisableFeat := union(baseDisableFeat, rtDisableFeat)
+	// Merge feature lists - one entry per canonical feature name, runtime
+	// replacing base on collision. A feature listed in both enable and disable
+	// stays in both; Chromium resolves that conflict as disabled.
+	mergedEnableFeat := mergeFeatureEntries(baseEnableFeat, rtEnableFeat)
+	mergedDisableFeat := mergeFeatureEntries(baseDisableFeat, rtDisableFeat)
 
 	var featureFlags []string
 	if len(mergedEnableFeat) > 0 {
@@ -281,8 +322,9 @@ func WriteFlagFile(path string, tokens []string) error {
 const KernelDisableFeaturesPrefix = "--kernel-disable-features="
 
 // TranslateKernelDisableFeatures folds any --kernel-disable-features tokens into the
-// single --disable-features token and returns the result. Values are unioned with any
-// existing disable list; ordering of unrelated tokens is preserved. Idempotent.
+// single --disable-features token and returns the result. Values are merged by
+// canonical feature name (runtime/kernel entries replacing base ones); ordering of
+// unrelated tokens is preserved. Idempotent.
 func TranslateKernelDisableFeatures(tokens []string) []string {
 	var kernelVals, disableVals []string
 	rest := make([]string, 0, len(tokens))
@@ -299,7 +341,7 @@ func TranslateKernelDisableFeatures(tokens []string) []string {
 	if len(kernelVals) == 0 {
 		return tokens
 	}
-	merged := union(disableVals, kernelVals)
+	merged := mergeFeatureEntries(disableVals, kernelVals)
 	rest = append(rest, "--disable-features="+strings.Join(merged, ","))
 	return rest
 }

--- a/server/lib/chromiumflags/chromiumflags.go
+++ b/server/lib/chromiumflags/chromiumflags.go
@@ -82,10 +82,11 @@ func union(base, rt []string) []string {
 }
 
 // canonicalFeatureName strips trial/parameter decoration from a feature-list
-// entry. Entries may be of the form Feature or Feature<Trial (Chromium splits
-// on '<' and registers only the part before it as the feature name).
+// entry. ParseEnableFeatureString (base/feature_list.cc) terminates the name
+// at the first of ':', '.', or '<' — parameter, group, and study separators
+// respectively.
 func canonicalFeatureName(entry string) string {
-	if i := strings.IndexByte(entry, '<'); i >= 0 {
+	if i := strings.IndexAny(entry, ":.<"); i >= 0 {
 		return entry[:i]
 	}
 	return entry

--- a/server/lib/chromiumflags/chromiumflags.go
+++ b/server/lib/chromiumflags/chromiumflags.go
@@ -274,3 +274,32 @@ func WriteFlagFile(path string, tokens []string) error {
 	data = append(data, '\n')
 	return os.WriteFile(path, data, 0o644)
 }
+
+// KernelDisableFeaturesPrefix is a kernel-namespaced switch for per-session feature
+// disabling. Chromium ignores unknown switches, so on images that predate translation
+// the token is inert instead of last-win clobbering boot-time --disable-features lists.
+const KernelDisableFeaturesPrefix = "--kernel-disable-features="
+
+// TranslateKernelDisableFeatures folds any --kernel-disable-features tokens into the
+// single --disable-features token and returns the result. Values are unioned with any
+// existing disable list; ordering of unrelated tokens is preserved. Idempotent.
+func TranslateKernelDisableFeatures(tokens []string) []string {
+	var kernelVals, disableVals []string
+	rest := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		switch {
+		case strings.HasPrefix(tok, KernelDisableFeaturesPrefix):
+			appendCSVInto(&kernelVals, strings.TrimPrefix(tok, KernelDisableFeaturesPrefix))
+		case strings.HasPrefix(tok, "--disable-features="):
+			appendCSVInto(&disableVals, strings.TrimPrefix(tok, "--disable-features="))
+		default:
+			rest = append(rest, tok)
+		}
+	}
+	if len(kernelVals) == 0 {
+		return tokens
+	}
+	merged := union(disableVals, kernelVals)
+	rest = append(rest, "--disable-features="+strings.Join(merged, ","))
+	return rest
+}

--- a/server/lib/chromiumflags/chromiumflags.go
+++ b/server/lib/chromiumflags/chromiumflags.go
@@ -81,12 +81,23 @@ func union(base, rt []string) []string {
 	return out
 }
 
-// canonicalFeatureName strips trial/parameter decoration from a feature-list
-// entry. ParseEnableFeatureString (base/feature_list.cc) terminates the name
-// at the first of ':', '.', or '<' — parameter, group, and study separators
-// respectively.
-func canonicalFeatureName(entry string) string {
+// canonicalEnableFeatureName strips trial/parameter decoration from an
+// --enable-features entry. Those go through ParseEnableFeatureString
+// (base/feature_list.cc), which terminates the name at the first of ':',
+// '.', or '<' — parameter, group, and study separators respectively.
+func canonicalEnableFeatureName(entry string) string {
 	if i := strings.IndexAny(entry, ":.<"); i >= 0 {
+		return entry[:i]
+	}
+	return entry
+}
+
+// canonicalDisableFeatureName strips decoration from a --disable-features
+// entry. That list bypasses ParseEnableFeatureString and is parsed by
+// RegisterOverridesFromCommandLine, which only splits on '<'; dots and colons
+// are part of the name.
+func canonicalDisableFeatureName(entry string) string {
+	if i := strings.IndexByte(entry, '<'); i >= 0 {
 		return entry[:i]
 	}
 	return entry
@@ -95,20 +106,22 @@ func canonicalFeatureName(entry string) string {
 // mergeFeatureEntries merges base and runtime feature-list entries into one
 // list holding a single entry per canonical feature name, preserving first-
 // seen order. A runtime entry replaces a base entry with the same canonical
-// name, and later entries replace earlier ones within a stream.
+// name, and later entries replace earlier ones within a stream. Entries are
+// canonicalized with canon, which differs between the enable and disable
+// switches.
 //
 // This matters because Chromium's FeatureList registers overrides keyed by
 // canonical name and keeps only the FIRST entry per name (try_emplace in
 // base/feature_list.cc RegisterOverride). Emitting two decorated variants of
-// one feature (e.g. base Foo<TrialA plus runtime Foo<TrialB) would therefore
+// one feature (e.g. base Foo<StudyA plus runtime Foo<StudyB) would therefore
 // let the base configuration silently win; collapsing here makes the emitted
 // switch carry exactly one deliberate configuration per feature.
-func mergeFeatureEntries(baseVals, rtVals []string) []string {
+func mergeFeatureEntries(baseVals, rtVals []string, canon func(string) string) []string {
 	index := make(map[string]int, len(baseVals)+len(rtVals))
 	out := make([]string, 0, len(baseVals)+len(rtVals))
 	add := func(vals []string) {
 		for _, v := range vals {
-			name := canonicalFeatureName(v)
+			name := canon(v)
 			if pos, ok := index[name]; ok {
 				out[pos] = v
 				continue
@@ -212,8 +225,8 @@ func MergeFlags(baseTokens, runtimeTokens []string) []string {
 	// Merge feature lists - one entry per canonical feature name, runtime
 	// replacing base on collision. A feature listed in both enable and disable
 	// stays in both; Chromium resolves that conflict as disabled.
-	mergedEnableFeat := mergeFeatureEntries(baseEnableFeat, rtEnableFeat)
-	mergedDisableFeat := mergeFeatureEntries(baseDisableFeat, rtDisableFeat)
+	mergedEnableFeat := mergeFeatureEntries(baseEnableFeat, rtEnableFeat, canonicalEnableFeatureName)
+	mergedDisableFeat := mergeFeatureEntries(baseDisableFeat, rtDisableFeat, canonicalDisableFeatureName)
 
 	var featureFlags []string
 	if len(mergedEnableFeat) > 0 {
@@ -342,7 +355,7 @@ func TranslateKernelDisableFeatures(tokens []string) []string {
 	if len(kernelVals) == 0 {
 		return tokens
 	}
-	merged := mergeFeatureEntries(disableVals, kernelVals)
+	merged := mergeFeatureEntries(disableVals, kernelVals, canonicalDisableFeatureName)
 	rest = append(rest, "--disable-features="+strings.Join(merged, ","))
 	return rest
 }

--- a/server/lib/chromiumflags/chromiumflags_test.go
+++ b/server/lib/chromiumflags/chromiumflags_test.go
@@ -330,3 +330,47 @@ func TestMergeFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestTranslateKernelDisableFeatures(t *testing.T) {
+	tests := []struct {
+		name   string
+		tokens []string
+		want   []string
+	}{
+		{
+			name:   "no kernel tokens is a no-op",
+			tokens: []string{"--foo", "--disable-features=A,B"},
+			want:   nil,
+		},
+		{
+			name:   "kernel token folds into existing disable list",
+			tokens: []string{"--foo", "--disable-features=A,B", "--kernel-disable-features=WebMCPTesting"},
+			want:   []string{"--foo", "--disable-features=A,B,WebMCPTesting"},
+		},
+		{
+			name:   "kernel token creates a disable list when none exists",
+			tokens: []string{"--foo", "--kernel-disable-features=WebMCPTesting,DevToolsWebMCPSupport"},
+			want:   []string{"--foo", "--disable-features=WebMCPTesting,DevToolsWebMCPSupport"},
+		},
+		{
+			name:   "multiple kernel tokens and duplicates are unioned",
+			tokens: []string{"--kernel-disable-features=A", "--bar", "--kernel-disable-features=B,A"},
+			want:   []string{"--bar", "--disable-features=A,B"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TranslateKernelDisableFeatures(tt.tokens)
+			if tt.want == nil {
+				if !reflect.DeepEqual(got, tt.tokens) {
+					t.Fatalf("expected unchanged input:\n got: %#v\nwant: %#v", got, tt.tokens)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("TranslateKernelDisableFeatures() mismatch:\n got: %#v\nwant: %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/lib/chromiumflags/chromiumflags_test.go
+++ b/server/lib/chromiumflags/chromiumflags_test.go
@@ -412,6 +412,18 @@ func TestMergeFeatureEntries(t *testing.T) {
 			rt:   nil,
 			want: []string{"Foo<B"},
 		},
+		{
+			name: "parameter-decorated variants collapse to one canonical name",
+			base: []string{"Foo:p/v1"},
+			rt:   []string{"Foo:p/v2"},
+			want: []string{"Foo:p/v2"},
+		},
+		{
+			name: "group-and-study decoration is stripped too",
+			base: []string{"Foo"},
+			rt:   []string{"Foo.G1<S"},
+			want: []string{"Foo.G1<S"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/lib/chromiumflags/chromiumflags_test.go
+++ b/server/lib/chromiumflags/chromiumflags_test.go
@@ -424,6 +424,18 @@ func TestMergeFeatureEntries(t *testing.T) {
 			rt:   nil,
 			want: []string{"Foo<B"},
 		},
+		{
+			name: "starred base is replaced by unstarred runtime",
+			base: []string{"*Foo"},
+			rt:   []string{"Foo"},
+			want: []string{"Foo"},
+		},
+		{
+			name: "unstarred base is replaced by starred runtime",
+			base: []string{"Foo"},
+			rt:   []string{"*Foo"},
+			want: []string{"*Foo"},
+		},
 	}
 
 	for _, tt := range enableCases {
@@ -458,6 +470,18 @@ func TestMergeFeatureEntries(t *testing.T) {
 			base: []string{"Foo:p/v1"},
 			rt:   []string{"Foo:p/v2"},
 			want: []string{"Foo:p/v1", "Foo:p/v2"},
+		},
+		{
+			name: "starred base is replaced by unstarred runtime",
+			base: []string{"*Foo"},
+			rt:   []string{"Foo"},
+			want: []string{"Foo"},
+		},
+		{
+			name: "unstarred base is replaced by starred runtime",
+			base: []string{"Foo"},
+			rt:   []string{"*Foo"},
+			want: []string{"*Foo"},
 		},
 	}
 

--- a/server/lib/chromiumflags/chromiumflags_test.go
+++ b/server/lib/chromiumflags/chromiumflags_test.go
@@ -376,7 +376,7 @@ func TestTranslateKernelDisableFeatures(t *testing.T) {
 }
 
 func TestMergeFeatureEntries(t *testing.T) {
-	tests := []struct {
+	enableCases := []struct {
 		name string
 		base []string
 		rt   []string
@@ -401,18 +401,6 @@ func TestMergeFeatureEntries(t *testing.T) {
 			want: []string{"Foo<TrialB"},
 		},
 		{
-			name: "distinct canonical names both survive in order",
-			base: []string{"Foo<ParamA/1", "Bar"},
-			rt:   []string{"Bar<TrialB", "Baz"},
-			want: []string{"Foo<ParamA/1", "Bar<TrialB", "Baz"},
-		},
-		{
-			name: "later entry replaces earlier within a stream",
-			base: []string{"Foo<A", "Foo<B"},
-			rt:   nil,
-			want: []string{"Foo<B"},
-		},
-		{
 			name: "parameter-decorated variants collapse to one canonical name",
 			base: []string{"Foo:p/v1"},
 			rt:   []string{"Foo:p/v2"},
@@ -424,11 +412,58 @@ func TestMergeFeatureEntries(t *testing.T) {
 			rt:   []string{"Foo.G1<S"},
 			want: []string{"Foo.G1<S"},
 		},
+		{
+			name: "distinct canonical names both survive in order",
+			base: []string{"Foo<ParamA/1", "Bar"},
+			rt:   []string{"Bar<TrialB", "Baz"},
+			want: []string{"Foo<ParamA/1", "Bar<TrialB", "Baz"},
+		},
+		{
+			name: "later entry replaces earlier within a stream",
+			base: []string{"Foo<A", "Foo<B"},
+			rt:   nil,
+			want: []string{"Foo<B"},
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := mergeFeatureEntries(tt.base, tt.rt)
+	for _, tt := range enableCases {
+		t.Run("enable/"+tt.name, func(t *testing.T) {
+			got := mergeFeatureEntries(tt.base, tt.rt, canonicalEnableFeatureName)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("mergeFeatureEntries() mismatch:\n got: %#v\nwant: %#v", got, tt.want)
+			}
+		})
+	}
+
+	disableCases := []struct {
+		name string
+		base []string
+		rt   []string
+		want []string
+	}{
+		{
+			name: "runtime trial variant replaces base trial variant",
+			base: []string{"Foo<A"},
+			rt:   []string{"Foo<B"},
+			want: []string{"Foo<B"},
+		},
+		{
+			name: "dotted names are distinct features on the disable switch",
+			base: []string{"Foo.G1"},
+			rt:   []string{"Foo.G2"},
+			want: []string{"Foo.G1", "Foo.G2"},
+		},
+		{
+			name: "colon stays in the name so param variants remain distinct",
+			base: []string{"Foo:p/v1"},
+			rt:   []string{"Foo:p/v2"},
+			want: []string{"Foo:p/v1", "Foo:p/v2"},
+		},
+	}
+
+	for _, tt := range disableCases {
+		t.Run("disable/"+tt.name, func(t *testing.T) {
+			got := mergeFeatureEntries(tt.base, tt.rt, canonicalDisableFeatureName)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("mergeFeatureEntries() mismatch:\n got: %#v\nwant: %#v", got, tt.want)
 			}

--- a/server/lib/chromiumflags/chromiumflags_test.go
+++ b/server/lib/chromiumflags/chromiumflags_test.go
@@ -41,12 +41,16 @@ func TestAppendCSVInto(t *testing.T) {
 
 func TestParseTokenStream_BaseAndRuntime(t *testing.T) {
 	var (
-		baseLoad    []string
-		baseExcept  []string
-		rtLoad      []string
-		rtExcept    []string
-		baseDisable string
-		rtDisable   string
+		baseLoad       []string
+		baseExcept     []string
+		rtLoad         []string
+		rtExcept       []string
+		baseDisable    string
+		rtDisable      string
+		baseEnableFeat []string
+		baseDisFeat    []string
+		rtEnableFeat   []string
+		rtDisFeat      []string
 	)
 
 	baseTokens := []string{
@@ -62,8 +66,8 @@ func TestParseTokenStream_BaseAndRuntime(t *testing.T) {
 		"--foo",
 	}
 
-	baseNonExt := parseTokenStream(baseTokens, &baseLoad, &baseExcept, &baseDisable)
-	runtimeNonExt := parseTokenStream(runtimeTokens, &rtLoad, &rtExcept, &rtDisable)
+	baseNonExt := parseTokenStream(baseTokens, &baseLoad, &baseExcept, &baseEnableFeat, &baseDisFeat, &baseDisable)
+	runtimeNonExt := parseTokenStream(runtimeTokens, &rtLoad, &rtExcept, &rtEnableFeat, &rtDisFeat, &rtDisable)
 
 	if !reflect.DeepEqual(baseLoad, []string{"/e1", "/e2"}) {
 		t.Fatalf("base load-extension parsed incorrectly: %#v", baseLoad)
@@ -127,16 +131,20 @@ func TestOverrideSemantics_DisableRuntime_Wins(t *testing.T) {
 	runtimeTokens := parseFlags(runtimeFlags)
 
 	var (
-		baseLoad       []string
-		baseExcept     []string
-		rtLoad         []string
-		rtExcept       []string
-		baseDisable    string
-		runtimeDisable string
+		baseLoad        []string
+		baseExcept      []string
+		rtLoad          []string
+		rtExcept        []string
+		baseEnableFeat  []string
+		baseDisableFeat []string
+		rtEnableFeat    []string
+		rtDisableFeat   []string
+		baseDisable     string
+		runtimeDisable  string
 	)
 
-	_ = parseTokenStream(baseTokens, &baseLoad, &baseExcept, &baseDisable)
-	_ = parseTokenStream(runtimeTokens, &rtLoad, &rtExcept, &runtimeDisable)
+	_ = parseTokenStream(baseTokens, &baseLoad, &baseExcept, &baseEnableFeat, &baseDisableFeat, &baseDisable)
+	_ = parseTokenStream(runtimeTokens, &rtLoad, &rtExcept, &rtEnableFeat, &rtDisableFeat, &runtimeDisable)
 
 	var extFlags []string
 	if runtimeDisable != "" {
@@ -286,6 +294,30 @@ func TestMergeFlags(t *testing.T) {
 			baseFlags:    []string{"--foo", "--load-extension=/e1", "--disable-extensions-except=/x1"},
 			runtimeFlags: []string{"--bar", "--load-extension=/e2", "--disable-extensions-except=/x2"},
 			want:         []string{"--foo", "--bar", "--load-extension=/e1,/e2,/x1,/x2"},
+		},
+		{
+			name:         "merge enable-features from base and runtime",
+			baseFlags:    []string{"--enable-features=WebMCPTesting"},
+			runtimeFlags: []string{"--enable-features=Foo"},
+			want:         []string{"--enable-features=WebMCPTesting,Foo"},
+		},
+		{
+			name:         "merge disable-features across sources",
+			baseFlags:    []string{"--disable-features=A,B"},
+			runtimeFlags: []string{"--disable-features=B,C"},
+			want:         []string{"--disable-features=A,B,C"},
+		},
+		{
+			name:         "runtime can opt out of a base-enabled feature via disable list",
+			baseFlags:    []string{"--enable-features=WebMCPTesting,DevToolsWebMCPSupport"},
+			runtimeFlags: []string{"--disable-features=WebMCPTesting"},
+			want:         []string{"--enable-features=WebMCPTesting,DevToolsWebMCPSupport", "--disable-features=WebMCPTesting"},
+		},
+		{
+			name:         "enable and disable features coexist across sources",
+			baseFlags:    []string{"--enable-features=A", "--disable-features=B"},
+			runtimeFlags: []string{"--enable-features=C", "--disable-features=D"},
+			want:         []string{"--enable-features=A,C", "--disable-features=B,D"},
 		},
 	}
 

--- a/server/lib/chromiumflags/chromiumflags_test.go
+++ b/server/lib/chromiumflags/chromiumflags_test.go
@@ -374,3 +374,52 @@ func TestTranslateKernelDisableFeatures(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeFeatureEntries(t *testing.T) {
+	tests := []struct {
+		name string
+		base []string
+		rt   []string
+		want []string
+	}{
+		{
+			name: "runtime decorated variant replaces base decorated variant",
+			base: []string{"Foo<TrialA"},
+			rt:   []string{"Foo<TrialB"},
+			want: []string{"Foo<TrialB"},
+		},
+		{
+			name: "runtime plain name replaces base decorated variant",
+			base: []string{"Foo<TrialA"},
+			rt:   []string{"Foo"},
+			want: []string{"Foo"},
+		},
+		{
+			name: "runtime decorated variant replaces base plain name",
+			base: []string{"Foo"},
+			rt:   []string{"Foo<TrialB"},
+			want: []string{"Foo<TrialB"},
+		},
+		{
+			name: "distinct canonical names both survive in order",
+			base: []string{"Foo<ParamA/1", "Bar"},
+			rt:   []string{"Bar<TrialB", "Baz"},
+			want: []string{"Foo<ParamA/1", "Bar<TrialB", "Baz"},
+		},
+		{
+			name: "later entry replaces earlier within a stream",
+			base: []string{"Foo<A", "Foo<B"},
+			rt:   nil,
+			want: []string{"Foo<B"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeFeatureEntries(tt.base, tt.rt)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("mergeFeatureEntries() mismatch:\n got: %#v\nwant: %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Enables WebMCP (Chromium's `navigator.modelContext` API plus its CDP domain) in default browser launch flags, and makes flag merging feature-list-aware so per-session flags can't silently drop image defaults.

### Feature strings

Verified against the Chromium 151 sources: `chrome://flags/#enable-webmcp-testing` maps to base feature **`WebMCPTesting`** (disabled by default; implies the runtime `WebMCP` feature in the renderer), and `devtools-webmcp-support` maps to **`DevToolsWebMCPSupport`**, which gates registration of the CDP `WebMCP` domain handler. Browser-side use also requires the `Tools` permissions policy (`EnableForSelf`, depends on WebMCP), which top-level pages get by default.

On Chromium 151+, `--enable-features=WebMCPTesting,DevToolsWebMCPSupport` turns on both the JS API and the WebMCP CDP domain.

### What changed

- Headless default flags (`server/cmd/wrapper/chromium.go`) and headful defaults (`images/chromium-headful/run-{unikernel,docker}.sh`): add `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`.
- `chromiumflags.MergeFlags`: union `--enable-features` / `--disable-features` CSV values across base and runtime sources into single tokens. Chromium keeps only one value per switch, so previously a session-supplied `--enable-features=X` would have silently dropped the image's entire default list (or vice versa). A feature present in both lists resolves to disabled inside Chromium, so sessions can still opt out with `--disable-features=WebMCPTesting`.
- `chromiumflags.TranslateKernelDisableFeatures`: folds a kernel-namespaced `--kernel-disable-features=` token into the single `--disable-features` switch at flag-assembly time (both in the launcher and before `/chromium/flags` is written). Chromium ignores unknown switches, so on images predating translation the token is inert — an opt-out degrades to a no-op instead of last-win clobbering boot-time disable lists.

### Tradeoffs

- Fingerprint: enabling by default exposes `navigator.modelContext` to pages, which stock Chrome 151 does not show without an origin trial or experimental-web-platform-features. Sites can detect that surface as a deviation. Callers that need stock-matching behavior can pass `--disable-features=WebMCPTesting,DevToolsWebMCPSupport` (or the kernel-namespaced token) through existing flag mechanisms; the control plane does this for stealth sessions.

### Testing

- `go test ./lib/chromiumflags/` — extended table tests for feature-list merging (union across sources, opt-out via disable list, coexistence) and for kernel-token translation (fold into existing list, create list when absent, idempotency). All pass.
- `go build ./...` and full `go test ./...` run; remaining failures (display/OTLP/extension e2e tests requiring a running Chromium/X environment) fail identically on main.