### PR TITLE
Reap the log aggregator's tail processes

### DIFF
--- a/server/cmd/wrapper/supervisord.go
+++ b/server/cmd/wrapper/supervisord.go
@@ -97,6 +97,17 @@ func tailFile(path string) {
 	for scanner.Scan() {
 		fmt.Printf("[%s] %s\n", label, scanner.Text())
 	}
+	// A clean scan ends when tail closes its stdout, i.e. when it has exited.
+	// A scan that ends on an error (a log line past the 1MB cap, say) leaves
+	// tail running, so kill it rather than block here forever.
+	//
+	// Either way we have to collect it: the wrapper is pid 1 in both the
+	// container and the unikernel, so a tail nobody waits on stays a zombie
+	// for the life of the instance.
+	if scanner.Err() != nil {
+		_ = cmd.Process.Kill()
+	}
+	_ = cmd.Wait()
 }
 
 func runStream(label, name string, args ...string) error {


### PR DESCRIPTION
## Summary

`tailFile` starts `tail -n +1 -F <path>` and reads its stdout, but never calls `Wait`. When that tail exits, nothing collects its status, so it stays a zombie.

The wrapper is pid 1 in both the container (`ENTRYPOINT`) and the unikernel (Kraftfile `cmd`), so there is no other init to clean up after it. On a long-lived instance whose services restart repeatedly, these accumulate for the life of the instance and each one holds a pid slot.

A clean scan ends exactly when tail closes its stdout, which is when it has exited, so that is where the wait belongs. A scan that ends on a read error instead is a different case: `bufio.Scanner` also stops on `ErrTooLong`, and there tail is still alive, so waiting would park the goroutine forever. Kill it first in that path.

## Testing

`go build`, `go vet`, `gofmt` and `go test -race` pass on `server/cmd/wrapper`.

No test added here. `tail -F` does not exit on its own and `tailFile` keeps no handle to the process, so there is no seam to drive it from a test without reshaping the function. The reaper PR stacked on this one carries tests that cover the same defect class directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to log tailing cleanup in the wrapper; no auth, data, or API surface impact.
> 
> **Overview**
> **`tailFile`** in the wrapper supervisord log aggregator previously started `tail -F` and read lines but never **`Wait()`** on the child. Because the wrapper runs as **pid 1** in container and unikernel, exited tails became **zombies** that could pile up when services restart.
> 
> After the scan loop, the change always **`Wait()`**s to reap the process. If **`scanner.Err()`** is set (e.g. a line exceeds the 1MB scanner limit while `tail` is still running), it **`Kill()`**s `tail` first so **`Wait()`** does not block forever.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a0f5565343ae3a69d98bdb5a59ecd5c31739f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->