### PR TITLE
e2e: wait for MV3 ping status via locator, not waitForFunction

### DIFF
--- a/server/e2e/playwright/index.ts
+++ b/server/e2e/playwright/index.ts
@@ -410,12 +410,12 @@ class CDPClient {
       console.log('[cdp] clicking Ping Service Worker button');
       const pingButton = this.page.getByRole('button', { name: 'Ping Service Worker' });
       await pingButton.click();
-      await this.page.waitForFunction(() => {
-        const status = document.querySelector('#status');
-        return status?.classList.contains('success') || status?.classList.contains('error');
-      }, undefined, { timeout });
-
-      const statusElement = this.page.locator('#status');
+      // Wait via locators, not waitForFunction: waitForFunction evals its
+      // predicate inside the page, and the popup's MV3 CSP (script-src 'self')
+      // intermittently blocks that eval while the service worker is still
+      // activating, failing the whole verification.
+      const statusElement = this.page.locator('#status.success, #status.error');
+      await statusElement.waitFor({ timeout });
       const statusText = await statusElement.textContent();
       console.log(`[cdp] status text: ${statusText}`);
 


### PR DESCRIPTION
## Summary

Fixes an intermittent `TestMV3ServiceWorkerRegistration` failure caused by the verification harness itself, not by extension loading.

### Failure mode

`verifyMV3ServiceWorker` clicks "Ping Service Worker" and then polls the popup status element with `page.waitForFunction(() => ...)`. Playwright's waitForFunction evaluates its predicate through `eval()` **inside the page**, and the popup is an MV3 extension page whose CSP is exactly `script-src 'self'` (no `unsafe-eval`). When the service worker is still activating when the poll starts — observed under CI parallel load, with the extension reported `(Inactive)` at discovery — the eval is CSP-blocked and the whole verification fails with:

```
page.waitForFunction: EvalError: Evaluating a string as JavaScript violates the
following Content Security Policy directive because 'unsafe-eval' is not an
allowed source of script: script-src 'self'
```

The failure screenshot showed the popup stuck in its "Sending ping to service worker..." pending state: the click had fired, the worker was mid-activation, and the very first poll threw. The same image passed every retry, which is what makes this so intermittent.

### Fix

Poll the status element through a locator instead:

```ts
const statusElement = this.page.locator('#status.success, #status.error');
await statusElement.waitFor({ timeout });
```

Locator resolution goes through Playwright's injected script and never evals caller-supplied strings, so the popup CSP cannot reject it. Semantics are unchanged: the wait resolves as soon as `#status` carries the `success` or `error` class, and the subsequent `textContent()` check still asserts on `SUCCESS`.

### Testing

- Reproduced the harness path against a real headless container (extension upload → chromium restart → popup → click): the locator-based wait resolved with `SUCCESS: Service worker is alive!` in 6/6 fresh-restart iterations.
- The old `waitForFunction` path passed those same iterations too (the race is rare), so this change is about removing the failure mode, not reproducing it on demand.
- No product code touched; test harness only.