### PR TITLE
Build chromium images on the shared buildx builder

### DIFF
--- a/.github/buildkitd.toml
+++ b/.github/buildkitd.toml
@@ -1,0 +1,34 @@
+# GC config for the shared persistent builder (deft-shared) on the
+# self-hosted runners. Mirrors BuildKit's default policy structure with two
+# changes: cache-mount/local-context records survive 7 days of disuse instead
+# of 48h (api-ecs is path-filtered and can idle past 48h), and total builder
+# storage is capped at 150GB with a 100GB free-space floor.
+#
+# The authoritative copy is installed on the host by kernel/infra
+# (roles/dev_shared_buildx_builder); this copy is the fallback if a job ever
+# recreates the builder. Keep the two in sync. BuildKit reads this only at
+# builder creation; applying a change requires `docker buildx rm deft-shared`.
+[worker.oci]
+  gc = true
+
+[[worker.oci.gcpolicy]]
+  filters = ["type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+  keepDuration = "168h"
+  maxUsedSpace = "40GB"
+
+[[worker.oci.gcpolicy]]
+  keepDuration = "1440h"
+  reservedSpace = "10GB"
+  minFreeSpace = "100GB"
+  maxUsedSpace = "150GB"
+
+[[worker.oci.gcpolicy]]
+  reservedSpace = "10GB"
+  minFreeSpace = "100GB"
+  maxUsedSpace = "150GB"
+
+[[worker.oci.gcpolicy]]
+  all = true
+  reservedSpace = "10GB"
+  minFreeSpace = "100GB"
+  maxUsedSpace = "150GB"

--- a/.github/workflows/chromium-headful-image.yaml
+++ b/.github/workflows/chromium-headful-image.yaml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   docker:
+    # Fork PRs get no secrets and now must not reach the self-hosted pool
+    # either: skipping here (rather than failing at registry login, as
+    # before) also skips the dependent e2e job via its needs chain.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
     permissions:
       contents: read

--- a/.github/workflows/chromium-headful-image.yaml
+++ b/.github/workflows/chromium-headful-image.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     permissions:
       contents: read
     steps:
@@ -17,6 +17,28 @@ jobs:
         shell: bash
         run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
+      # The docker build context must match the git tree exactly, including
+      # file modes: BuildKit's COPY cache key covers permission bits, and the
+      # runners' persistent _work checkouts carry modes frozen from whatever
+      # umask was active when each file was first written, which differs per
+      # runner and busts the layer cache on the shared builder.
+      - name: Reset workspace to a pristine build context
+        run: |
+          git checkout -- .
+          git clean -xdf
+          find . -path ./.git -prune -o -type f -perm -u+x -print0 | xargs -0 -r chmod 755
+          find . -path ./.git -prune -o -type f ! -perm -u+x -print0 | xargs -0 -r chmod 644
+
+      - name: Create isolated Docker config
+        run: |
+          DOCKER_CONFIG="$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")"
+          echo "DOCKER_CONFIG=${DOCKER_CONFIG}" >> "$GITHUB_ENV"
+          # BUILDX_CONFIG defaults to $DOCKER_CONFIG/buildx; without this the
+          # isolated DOCKER_CONFIG above would hide the shared builder. The
+          # buildx-ci path (not the default ~/.docker/buildx) avoids the tree
+          # that root-run CI from other repos clobbers to root-owned.
+          echo "BUILDX_CONFIG=${HOME}/.docker/buildx-ci" >> "$GITHUB_ENV"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -25,13 +47,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          name: deft-shared
+          cleanup: false
+          buildkitd-config: .github/buildkitd.toml
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          builder: deft-shared
           context: .
           file: images/chromium-headful/Dockerfile
           push: true
           tags: onkernel/chromium-headful:${{ steps.vars.outputs.short_sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/chromium-headless-image.yaml
+++ b/.github/workflows/chromium-headless-image.yaml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   docker:
+    # Fork PRs get no secrets and now must not reach the self-hosted pool
+    # either: skipping here (rather than failing at registry login, as
+    # before) also skips the dependent e2e job via its needs chain.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
     permissions:
       contents: read

--- a/.github/workflows/chromium-headless-image.yaml
+++ b/.github/workflows/chromium-headless-image.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     permissions:
       contents: read
     steps:
@@ -17,6 +17,28 @@ jobs:
         shell: bash
         run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
+      # The docker build context must match the git tree exactly, including
+      # file modes: BuildKit's COPY cache key covers permission bits, and the
+      # runners' persistent _work checkouts carry modes frozen from whatever
+      # umask was active when each file was first written, which differs per
+      # runner and busts the layer cache on the shared builder.
+      - name: Reset workspace to a pristine build context
+        run: |
+          git checkout -- .
+          git clean -xdf
+          find . -path ./.git -prune -o -type f -perm -u+x -print0 | xargs -0 -r chmod 755
+          find . -path ./.git -prune -o -type f ! -perm -u+x -print0 | xargs -0 -r chmod 644
+
+      - name: Create isolated Docker config
+        run: |
+          DOCKER_CONFIG="$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")"
+          echo "DOCKER_CONFIG=${DOCKER_CONFIG}" >> "$GITHUB_ENV"
+          # BUILDX_CONFIG defaults to $DOCKER_CONFIG/buildx; without this the
+          # isolated DOCKER_CONFIG above would hide the shared builder. The
+          # buildx-ci path (not the default ~/.docker/buildx) avoids the tree
+          # that root-run CI from other repos clobbers to root-owned.
+          echo "BUILDX_CONFIG=${HOME}/.docker/buildx-ci" >> "$GITHUB_ENV"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -25,13 +47,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          name: deft-shared
+          cleanup: false
+          buildkitd-config: .github/buildkitd.toml
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          builder: deft-shared
           context: .
           file: images/chromium-headless/image/Dockerfile
           push: true
           tags: onkernel/chromium-headless:${{ steps.vars.outputs.short_sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
Moves the headful and headless image builds from 2-core hosted runners to the self-hosted pool, attached to the persistent deft-shared buildx builder (same setup as kernel/kernel's image builds). The builder's local layer store replaces type=gha caching, which was churning against the repo's 10GB Actions cache quota and making build times a lottery (79-700s). Docker Hub push, tags, and the e2e flow are unchanged.

Measured on this PR's own CI (run 33197223789):

| build | before (hosted) | cold | warm |
|---|---|---|---|
| chromium-headless | 79-700s | 242s | 6s |
| chromium-headful | 79-700s | 375s | 7s |

The pristine-context reset and isolated Docker config are ported from kernel/kernel's auth-flow-simulator workflow; .github/buildkitd.toml is the recreate-fallback config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI infrastructure (self-hosted runners, shared builder, fork skip) and image build caching; runtime images and push tags are unchanged but fork PRs no longer run these image/e2e jobs.
> 
> **Overview**
> Moves **chromium-headful** and **chromium-headless** Docker builds from GitHub-hosted runners to **self-hosted** runners using the persistent **`deft-shared`** Buildx builder, matching the pattern used elsewhere in the org.
> 
> **Caching and config:** Drops `type=gha` cache import/export in favor of the builder’s local layer store. Adds **`.github/buildkitd.toml`** as a recreate fallback (longer retention for cache mounts/local context, **150GB** storage cap with **100GB** free-space floor). Buildx setup pins **`deft-shared`**, **`cleanup: false`**, and that config file.
> 
> **Runner hygiene:** Before build, jobs reset the checkout to a **pristine context** (clean + normalized file modes) so COPY cache keys stay stable on persistent workspaces. They also use a **temp `DOCKER_CONFIG`** while pointing **`BUILDX_CONFIG`** at `~/.docker/buildx-ci` so registry login stays isolated without losing the shared builder.
> 
> **Fork PRs:** The docker job is **skipped** when the PR head is from a fork (no secrets and no self-hosted pool), which propagates to dependent e2e via `needs` instead of failing at Docker Hub login.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d3eb63ea6fe448bb892c95809f21871abd54f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->