### PR TITLE
Recover WebMCP sessions after missed events

### DIFF
--- a/server/lib/browsersurface/frames.go
+++ b/server/lib/browsersurface/frames.go
@@ -141,12 +141,11 @@ func (t *Tracker) initializeSession(sessionID string) {
 }
 
 func (t *Tracker) failSessionInitialization(sessionID string, err error) {
-	t.stateMu.Lock()
-	if tracked := t.sessions[sessionID]; tracked != nil {
-		tracked.initializing = false
-	}
-	t.stateMu.Unlock()
+	t.removeSession(sessionID)
 	if !t.protocol.IsClosed() {
+		ctx, cancel := context.WithTimeout(t.ctx, time.Second)
+		_, _ = t.protocol.Send(ctx, "Target.detachFromTarget", map[string]any{"sessionId": sessionID}, "")
+		cancel()
 		t.logger.Warn("failed to initialize browser surface session", "session_id", sessionID, "err", err)
 	}
 }

--- a/server/lib/browsersurface/targets.go
+++ b/server/lib/browsersurface/targets.go
@@ -156,13 +156,11 @@ func (t *Tracker) RefreshTargets(ctx context.Context) error {
 		}
 		t.removeTarget(targetID)
 	}
-	t.stateMu.Lock()
 	for _, targetID := range knownFrames {
 		if !activeFrames[targetID] {
-			delete(t.trackingFrameTarget, targetID)
+			t.removeTarget(targetID)
 		}
 	}
-	t.stateMu.Unlock()
 	return nil
 }
 

--- a/server/lib/browsersurface/tracker_test.go
+++ b/server/lib/browsersurface/tracker_test.go
@@ -17,6 +17,7 @@ type fakeProtocol struct {
 	windowIDs           map[string]int
 	attachFailures      int
 	attachCalls         map[string]int
+	detachCalls         map[string]int
 	pageEnableFailures  map[string]int
 	pageEnableCalls     map[string]int
 	frameTreeFailures   map[string]int
@@ -29,6 +30,7 @@ func newFakeProtocol() *fakeProtocol {
 	return &fakeProtocol{
 		windowIDs:          map[string]int{"page-a": 10, "page-b": 20},
 		attachCalls:        make(map[string]int),
+		detachCalls:        make(map[string]int),
 		pageEnableFailures: make(map[string]int),
 		pageEnableCalls:    make(map[string]int),
 		frameTreeFailures:  make(map[string]int),
@@ -77,6 +79,12 @@ func (f *fakeProtocol) Send(_ context.Context, method string, params any, sessio
 			"page-a": "session-a", "page-b": "session-b", "late-page": "late-session", "oopif": "oopif-session",
 		}[targetID]
 		return marshal(map[string]any{"sessionId": sessionID}), nil
+	case "Target.detachFromTarget":
+		detachedSessionID := params.(map[string]any)["sessionId"].(string)
+		f.mu.Lock()
+		f.detachCalls[detachedSessionID]++
+		f.mu.Unlock()
+		return marshal(map[string]any{}), nil
 	case "Page.enable":
 		f.mu.Lock()
 		f.pageEnableCalls[sessionID]++
@@ -187,6 +195,33 @@ func TestTrackerRetriesTransientSessionInitializationFailure(t *testing.T) {
 			}, time.Second, 10*time.Millisecond)
 		})
 	}
+}
+
+func TestTrackerReattachesAfterTerminalSessionInitializationFailure(t *testing.T) {
+	protocol := newFakeProtocol()
+	tracker := New(protocol)
+	require.NoError(t, tracker.Start(context.Background()))
+	require.Eventually(t, func() bool {
+		_, resolved := tracker.Resolve("session-a", "root-a")
+		return resolved
+	}, time.Second, 10*time.Millisecond)
+
+	tracker.stateMu.Lock()
+	tracker.sessions["session-a"].initialized = false
+	tracker.sessions["session-a"].initializing = true
+	tracker.stateMu.Unlock()
+	tracker.failSessionInitialization("session-a", errors.New("initialization deadline exceeded"))
+	require.False(t, tracker.SessionExists("session-a"))
+
+	require.NoError(t, tracker.RefreshTargets(context.Background()))
+	require.Eventually(t, func() bool {
+		_, resolved := tracker.Resolve("session-a", "root-a")
+		return resolved
+	}, time.Second, 10*time.Millisecond)
+	protocol.mu.Lock()
+	defer protocol.mu.Unlock()
+	require.Equal(t, 2, protocol.attachCalls["page-a"])
+	require.Equal(t, 1, protocol.detachCalls["session-a"])
 }
 
 func TestTrackerStopsInitializationRetriesAfterSessionRemoval(t *testing.T) {
@@ -355,6 +390,37 @@ func TestTrackerRefreshDoesNotRemoveTabCreatedAfterSnapshot(t *testing.T) {
 		}
 	}
 	require.True(t, found)
+}
+
+func TestTrackerRefreshRemovesMissingFrameTargetSession(t *testing.T) {
+	protocol := newFakeProtocol()
+	tracker := New(protocol)
+	events, cancel := tracker.Subscribe()
+	defer cancel()
+	require.NoError(t, tracker.Start(context.Background()))
+
+	protocol.emitTarget("Target.targetCreated", map[string]any{"targetInfo": map[string]any{
+		"targetId": "oopif", "type": "iframe", "url": "https://cross-origin.example/",
+		"parentFrameId": "root-a",
+	}})
+	require.Eventually(t, func() bool {
+		_, resolved := tracker.Resolve("oopif-session", "oopif")
+		return resolved
+	}, time.Second, 10*time.Millisecond)
+
+	// Target.getTargets omits oopif, simulating a missed targetDestroyed event.
+	require.NoError(t, tracker.RefreshTargets(context.Background()))
+	require.False(t, tracker.SessionExists("oopif-session"))
+	_, resolved := tracker.Resolve("oopif-session", "oopif")
+	require.False(t, resolved)
+	require.Eventually(t, func() bool {
+		select {
+		case event := <-events:
+			return event.Kind == EventSessionRemoved && event.SessionID == "oopif-session"
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestTrackerRetriesTabsAfterAttachFailure(t *testing.T) {

--- a/server/lib/webmcpclient/client_test.go
+++ b/server/lib/webmcpclient/client_test.go
@@ -63,6 +63,8 @@ type fakeCDP struct {
 	invokeResponseDelay     time.Duration
 	toolCount               int
 	popupOpen               bool
+	iframeOpen              bool
+	nestedFrameOpen         bool
 	write                   func(any)
 }
 
@@ -143,6 +145,18 @@ func (f *fakeCDP) serve(w http.ResponseWriter, r *http.Request) {
 			if f.popupOpen {
 				targets = append(targets, map[string]any{"targetId": "popup-target", "type": "page", "title": "Popup", "url": "https://popup.example/"})
 			}
+			if f.iframeOpen {
+				targets = append(targets, map[string]any{
+					"targetId": "iframe-target", "type": "iframe", "url": "https://payments.example/element#private-state",
+					"parentFrameId": "page-frame",
+				})
+			}
+			if f.nestedFrameOpen {
+				targets = append(targets, map[string]any{
+					"targetId": "nested-target", "type": "iframe", "url": "https://bank.example/challenge",
+					"parentFrameId": "iframe-frame",
+				})
+			}
 			f.mu.Unlock()
 			respond(map[string]any{"targetInfos": targets})
 		case "Browser.getWindowForTarget":
@@ -170,6 +184,9 @@ func (f *fakeCDP) serve(w http.ResponseWriter, r *http.Request) {
 			respond(map[string]any{"sessionId": sessionID})
 			switch params.TargetID {
 			case "page-target":
+				f.mu.Lock()
+				f.iframeOpen = true
+				f.mu.Unlock()
 				write(map[string]any{
 					"method": "Target.targetCreated",
 					"params": map[string]any{"targetInfo": map[string]any{
@@ -178,6 +195,9 @@ func (f *fakeCDP) serve(w http.ResponseWriter, r *http.Request) {
 					}},
 				})
 			case "iframe-target":
+				f.mu.Lock()
+				f.nestedFrameOpen = true
+				f.mu.Unlock()
 				write(map[string]any{
 					"method": "Target.targetCreated",
 					"params": map[string]any{"targetInfo": map[string]any{


### PR DESCRIPTION
## Summary

- remove and detach page sessions that exhaust browser-surface initialization so a later target refresh can attach a fresh CDP session
- reconcile iframe targets that disappear from `Target.getTargets`, removing stale sessions and their WebMCP registrations even when a destroy event is missed
- model active iframe targets in the WebMCP CDP test server and add focused recovery regressions

## Why

Browser-surface reconciliation recovered failed target attachment and missing page targets, but two terminal paths only cleared bookkeeping flags. A session that exhausted initialization could remain permanently ineligible for reattachment, while a missed iframe destroy event could leave stale tools discoverable.

## Testing

- `go test -race -count=100 ./lib/browsersurface`
- `go test -race -count=20 ./lib/browsersurface ./lib/webmcpclient`
- `go vet ./...`
- full non-E2E `go test -race`
