### PR TITLE
Report live view timeouts to parent frame

### DIFF
--- a/images/chromium-headful/client/src/app.vue
+++ b/images/chromium-headful/client/src/app.vue
@@ -209,6 +209,7 @@
 
     shakeKbd = false
     wasConnected = false
+    readOnlyOverride: boolean | null = null
 
     get volume() {
       const numberParam = parseFloat(new URL(location.href).searchParams.get('volume') || '1.0')
@@ -224,6 +225,10 @@
     }
 
     get isReadOnlyMode() {
+      if (this.readOnlyOverride !== null) {
+        return this.readOnlyOverride
+      }
+
       const params = new URL(location.href).searchParams
       const value = params.get('readOnly') || params.get('readonly') || params.get('ro')
       return typeof value === 'string' && ['1', 'true', 'yes'].includes(value.toLowerCase())
@@ -326,11 +331,44 @@
       }
 
       if (this.isReadOnlyMode) {
+        this.applyReadOnlyMode(true, false)
+      }
+    }
+
+    mounted() {
+      window.addEventListener('message', this.onParentMessage)
+    }
+
+    beforeDestroy() {
+      window.removeEventListener('message', this.onParentMessage)
+    }
+
+    private onParentMessage(event: MessageEvent) {
+      if (event.source !== window.parent) return
+      if (this.parentOrigin !== '*' && event.origin !== this.parentOrigin) return
+
+      const data = event.data as { type?: string; readOnly?: unknown }
+      if (data?.type !== 'KERNEL_SET_READ_ONLY' || typeof data.readOnly !== 'boolean') return
+
+      this.applyReadOnlyMode(data.readOnly, true)
+    }
+
+    private applyReadOnlyMode(readOnly: boolean, releaseControl: boolean) {
+      this.readOnlyOverride = readOnly
+
+      if (readOnly) {
+        if (releaseControl) {
+          this.$accessor.remote.release()
+        }
         // Disable implicit hosting so the user doesn't automatically gain control
         this.$accessor.remote.setImplicitHosting(false)
         // Lock the session locally to block any input even if hosting is later requested
         this.$accessor.remote.setLocked(true)
+        return
       }
+
+      this.$accessor.remote.setLocked(false)
+      this.$accessor.remote.setImplicitHosting(true)
     }
 
     // KERNEL: end custom resolution, frame rate, and readOnly control via query params

--- a/images/chromium-headful/client/src/neko/base.ts
+++ b/images/chromium-headful/client/src/neko/base.ts
@@ -407,6 +407,21 @@ export abstract class BaseClient extends EventEmitter<BaseEvents> {
     this.emit('error', (event as ErrorEvent).error)
   }
 
+  private postParentMessage(message: Record<string, unknown>) {
+    if (window.parent === window) {
+      return
+    }
+
+    let targetOrigin = '*'
+    try {
+      if (document.referrer) {
+        targetOrigin = new URL(document.referrer).origin
+      }
+    } catch (e) {}
+
+    window.parent.postMessage(message, targetOrigin)
+  }
+
   private onConnected() {
     if (this._timeout) {
       clearTimeout(this._timeout)
@@ -424,6 +439,14 @@ export abstract class BaseClient extends EventEmitter<BaseEvents> {
 
   private onTimeout() {
     this.emit('debug', `connection timeout`)
+    this.postParentMessage({
+      type: 'KERNEL_CONNECTION_TIMEOUT',
+      reason: 'connection timeout',
+      iceConnectionState: this._peer?.iceConnectionState ?? this._state,
+      connectionState: this._peer?.connectionState,
+      signalingState: this._peer?.signalingState,
+      socketOpen: this.socketOpen,
+    })
     if (this._timeout) {
       clearTimeout(this._timeout)
       this._timeout = undefined


### PR DESCRIPTION
## tldr
Telemetry only: post live-view connection timeouts from the Neko client to the dashboard parent frame, and let the parent toggle read-only mode without remounting the iframe.

## why
- #3736 classifies GPU live-view startup OOM failures in the dashboard. It listens for `KERNEL_CONNECTION_TIMEOUT`, so the dashboard needs this client-side trigger on the image path.
- The read-only toggle lets the dashboard update read-only mode without forcing an iframe remount that loses live-view connection context.

## what landed
- `images/chromium-headful/client/src/neko/base.ts`: on the 15s connect watchdog, post `KERNEL_CONNECTION_TIMEOUT` to the parent frame with connection state, signaling state, ICE state, and socket-open state.
- `images/chromium-headful/client/src/app.vue`: accept parent-frame `KERNEL_SET_READ_ONLY` messages and apply them inside the existing iframe.
- This PR does not change ICE policy, retry behavior, or relay selection.

## Experimental validation
- Built the PR client with `npm run build`; build completed with existing lint and bundle-size warnings only.
- Created an isolated 1920x1080 browser, enabled `kernel browsers ssh`, preserved the deployed `/var/www` baseline, uploaded the rebuilt PR client bundle, switched `/var/www` over SSH, and restarted only Neko.
- Confirmed the patched assets were served: `index.html` hash `c84a228c`, `js/app.7a4770f2.js` hash `3cd72c95`, and `css/app.17c6fbe4.css` hash `c7ed981d`.
- Live-tested normal playback through the patched client: video reached `readyState=4`, `paused=false`, rendered `1920x1080`, and `currentTime` advanced from `0.845` to `1.559` over the check window.
- Live-tested parent read-only updates through an iframe harness: posting `KERNEL_SET_READ_ONLY` with `readOnly=true` changed the overlay from `pointer-events: auto` to `none`; posting `readOnly=false` restored it to `auto`.
- Rechecked the read-only state after a delay to cover the Cursor bot concern about a later release response clearing the local lock; the overlay stayed at `pointer-events: none` after 3s.
- Live-tested timeout telemetry with the real patched client loaded in an iframe and a deterministic stalled WebRTC state: the parent frame received `KERNEL_CONNECTION_TIMEOUT` with `reason="connection timeout"`, `iceConnectionState="disconnected"`, and `socketOpen=false`.

## out of scope
- Retry escalation and ICE policy changes; those belong in a separate generic live-view recovery change.
- A full audit of ICE lifecycles with routing policies, rate limits, and hard state resets.