### PR TITLE
Make WebMCP request errors self-describing in message text

### DIFF
--- a/server/runtime/webmcp.test.ts
+++ b/server/runtime/webmcp.test.ts
@@ -85,11 +85,29 @@ test('preserves structured WebMCP failures', async () => {
     assert.equal(error.statusCode, 504);
     assert.equal(error.code, 'outcome_unknown');
     assert.equal(error.invocationId, 'invocation-1');
+    assert.equal(
+      error.message,
+      'WebMCP outcome_unknown, invocation invocation-1: do not retry automatically',
+    );
     assert.deepEqual(error.body, {
       code: 'outcome_unknown',
       message: 'do not retry automatically',
       invocation_id: 'invocation-1',
     });
+    return true;
+  });
+});
+
+test('names WebMCP failures without a structured body', async () => {
+  const client = createWebMCPClient({
+    apiBaseUrl: 'http://127.0.0.1:10001',
+    fetchImpl: async () => new Response('gateway timeout', {status: 504}),
+  });
+
+  await assert.rejects(client.listTools(), error => {
+    assert.ok(error instanceof WebMCPRequestError);
+    assert.equal(error.message, 'WebMCP error: request failed with status 504');
+    assert.equal(error.body, 'gateway timeout');
     return true;
   });
 });

--- a/server/runtime/webmcp.ts
+++ b/server/runtime/webmcp.ts
@@ -48,16 +48,22 @@ export class WebMCPRequestError extends Error {
 
   constructor(statusCode: number, body: unknown) {
     const fields = isRecord(body) ? body : {};
-    const message =
+    const code = typeof fields.code === 'string' ? fields.code : undefined;
+    const invocationId =
+      typeof fields.invocation_id === 'string' ? fields.invocation_id : undefined;
+    const detail =
       typeof fields.message === 'string'
         ? fields.message
-        : `WebMCP request failed with status ${statusCode}`;
-    super(message);
+        : `request failed with status ${statusCode}`;
+    // The Playwright daemon only forwards error.message, so the message itself
+    // must identify this as a WebMCP failure and carry the code and invocation.
+    const parts = [`WebMCP ${code ?? 'error'}`];
+    if (invocationId) parts.push(`invocation ${invocationId}`);
+    super(`${parts.join(', ')}: ${detail}`);
     this.name = 'WebMCPRequestError';
     this.statusCode = statusCode;
-    this.code = typeof fields.code === 'string' ? fields.code : undefined;
-    this.invocationId =
-      typeof fields.invocation_id === 'string' ? fields.invocation_id : undefined;
+    this.code = code;
+    this.invocationId = invocationId;
     this.body = body;
   }
 }


### PR DESCRIPTION
## Summary

The Playwright daemon forwards only `error.message` and `error.stack` when submitted code throws, so a `WebMCPRequestError` from `webmcp.invokeTool()` reached callers as a bare upstream message such as `the invocation started, but its final outcome could not be observed; do not retry automatically`, with no indication that it was a WebMCP failure, which error code it carried, or which invocation it referred to.

`WebMCPRequestError` now builds its message as `WebMCP <code>[, invocation <id>]: <detail>`, e.g. `WebMCP outcome_unknown, invocation 7419DF2C...: the invocation started, but its final outcome could not be observed; do not retry automatically`. The structured `statusCode`, `code`, `invocationId`, and `body` fields are unchanged, and the API response shape is unchanged; only the message text is more informative.

## Testing

- `node --test runtime/*.test.ts` passes (13 tests), including a new assertion on the message format and a new test for non-JSON error bodies.