### PR TITLE
Add durable agent transport acceptance suite

### DIFF
--- a/server/experiments/agenttransport/DESIGN.md
+++ b/server/experiments/agenttransport/DESIGN.md
@@ -1,0 +1,175 @@
+# ACP-first service boundary (proposal)
+
+This is a proposed production contract, not an implemented HTTP API. The current
+`/commands`, `/permissions`, `/cancel`, and `/snapshot` routes are private acceptance
+fixtures. They must not become a second public conversation protocol. Harness
+fan-out remains on hold while the lifecycle and configuration contract is settled.
+
+## Reuse ACP for interaction
+
+Keep a small runtime control surface separate from ACP:
+
+| Proposed endpoint | Responsibility |
+| --- | --- |
+| `POST /agent/v1/runtimes` | Prepare a pinned launch configuration and start its agent/adapter process. |
+| `GET /agent/v1/runtimes/{id}` | Process generation, readiness, resume identity, effective configuration (redacted), outstanding uncertain operations. |
+| `POST /agent/v1/runtimes/{id}/acp` | Accept an ACP JSON-RPC request, notification, or response without changing its payload schema. |
+| `GET /agent/v1/runtimes/{id}/acp` | Sequenced, resumable SSE containing original ACP server messages; distinguish runtime lifecycle events from ACP messages. |
+| `POST /agent/v1/runtimes/{id}/reset` | Explicit, idempotent process replacement and restoration of the same conversation. |
+
+Explicit runtime termination is also needed; closing an HTTP connection is never
+termination. Start with one managed conversation per runtime. Multi-session ACP
+processes and multiple concurrent writers are not part of the initial contract.
+
+Use standard ACP methods for `initialize`, `authenticate`, `session/new`,
+`session/prompt`, `session/cancel`, `session/load`, `session/resume`, and supported
+configuration methods. Advertise only client capabilities that the service can
+actually fulfill. The current driver does not provide filesystem/terminal
+callbacks; this is not a transparent implementation of every ACP capability.
+
+The fixture mappings are:
+
+- `/commands` -> `session/prompt`; `prompt` is already an ACP ContentBlock array.
+- `/cancel` -> `session/cancel`, which is a notification, not an RPC request.
+- `/permissions` -> a JSON-RPC response to `session/request_permission`, with the
+  offered ACP outcome/option ID. There is no ACP `session/permissions` method.
+- `/events` -> agent `session/update` notifications, requests, and RPC results/errors.
+- `/snapshot` -> Kernel transport/recovery state; there is no corresponding ACP method.
+
+The additions to ACP are narrowly scoped: durable HTTP acceptance, operation
+idempotency, replay cursors, and runtime generation/lifecycle state. A stable
+HTTP idempotency key must apply to notifications and permission responses too;
+JSON-RPC IDs alone are not durable operation identities. Reject stale-generation
+controls, namespace native request IDs by generation, and check duplicate requests
+before generation/admission checks so lost acknowledgements remain retryable.
+
+An HTTP 202 acknowledges journal persistence. The actual ACP result/error arrives
+on SSE with its JSON-RPC ID. A prompt result means turn completion, not acceptance.
+SSE IDs support exclusive replay after the last applied event. Reconnect is not
+`session/load`: the still-running process should not be restarted or re-prompted.
+
+ACP's remote HTTP transport is still an active proposal and explicitly defers
+reliable delivery replay. This binding must be named/versioned as a Kernel
+extension, not advertised as conformance to a finalized ACP HTTP standard.
+
+## Content, not a text wrapper
+
+The fixture now journals and forwards ACP content arrays, preserving block order,
+annotations, `_meta`, media data, resource links, and embedded text/blob resources.
+It also journals unmodified prompt responses/errors, not just streamed updates.
+
+The shared service performs structural validation and bounds encoded prompts to
+4 MiB. It does not duplicate the entire ACP content schema. The driver rejects
+optional content unless the agent advertises the relevant prompt capability:
+`image`, `audio`, or `embeddedContext`. Text and resource links are baseline ACP
+content. A model may still reject content despite an agent-level capability;
+that must surface as an error, never silent conversion or omission.
+
+Deterministic content tests cover HTTP -> journal -> ACP subprocess -> SSE ->
+reopened journal, content above the old 64 KiB HTTP limit, metadata/large integer
+preservation, equivalent-JSON retries, changed-content conflicts, buffer ownership,
+and unsupported capability rejection before dispatch. Media in the echo peer is
+opaque fixture data; this proves transport fidelity, not model media comprehension.
+Real harness tests must separately check valid supported media and resources.
+
+This changes the experimental prompt wire shape from a string to an array. Use a
+new evidence/journal directory; no legacy journal migration is implemented.
+
+## Restore a conversation, not an interrupted side effect
+
+ACP v1 already defines:
+
+- `session/load`, gated by `agentCapabilities.loadSession`: restore context and
+  replay conversation history with `session/update` before returning.
+- `session/resume`, gated by `agentCapabilities.sessionCapabilities.resume`:
+  restore context without replaying history. This is stable, not just an RFD.
+
+Neither method is an exactly-once checkpoint for arbitrary tools. Neither promises
+that a half-finished prompt, shell command, or remote MCP side effect is resumed
+safely. Native persisted history can also lag the transport journal after a crash.
+
+Persist the ACP session ID, adapter-specific native resume handle when different,
+configuration revision, workspace, and runtime generation. ACP IDs need not equal
+CLI-native IDs; a native session file may not exist yet immediately after creation.
+Never infer a resume target using a CLI's "latest session" flag.
+
+Proposed reset procedure:
+
+1. Journal the reset's stable operation ID and expected generation. Require explicit
+   acknowledgement of the interrupted/uncertain operation when resetting a busy
+   or crashed runtime; do not guess on behalf of a background reconnect.
+2. Stop admission, invalidate old approvals, and stop/reap the old process group.
+   Record any unconfirmed old turn as `uncertain`; do not relabel it successful.
+3. Start a new generation using the same configuration revision and persistent
+   session storage. Reinitialize and authenticate as needed.
+4. Use advertised `session/resume`, otherwise `session/load`. If neither is supported
+   or the exact native session is missing, fail explicitly; never silently create
+   a new conversation. Capture fallback load history separately from delivery replay
+   so restarting does not append duplicate historical messages to the live log.
+5. Persist readiness after successful restoration. Permit a new, explicitly submitted
+   prompt while retaining the old operation's uncertain outcome and deduplication.
+
+The implementation currently fences uncertain sessions permanently because it has
+no reset/reconciliation operation. That is an experimental safety limit, not the
+intended product behavior. Reset is not implemented by this change.
+
+Before enabling reset for a harness, test a fresh process with the exact saved ID,
+context continuity, same-ID retry after reset, stale permission rejection, and
+no model/tool auto-continuation during restore. Kill during tool and approval
+boundaries, and during reset itself. Local process termination cannot cancel an
+external side effect already accepted by a remote service.
+
+## Configuration may write files; make the scope explicit
+
+Do not require callers to reverse-engineer CLI flags, installation commands, or
+MCP config files. Accept declarative startup configuration and materialize it
+before the runtime becomes ready. Keep ACP's `mcpServers` schema and configuration
+methods instead of inventing alternative MCP or model-setting protocols.
+
+Separate three scopes:
+
+- **Runtime/session-owned (default):** generated settings, credentials, MCP overrides,
+  extension selection, writable caches, and native session storage. Persist these
+  across reset. Use harness-specific directory overrides and explicit config APIs.
+- **Shared pinned artifacts:** downloaded harness/adapter/extension packages. Resolve
+  versions and integrity once; concurrent preparation uses locks and atomic publish.
+  Sharing package bytes must not imply sharing mutable activation settings.
+- **Explicit workspace/shared configuration:** opt-in writes affecting other sessions.
+  Record a revision and serialize preparation. Existing processes keep their resolved
+  configuration until explicitly restarted; do not promise arbitrary extensions can
+  be transactionally rolled back.
+
+For Pi, `PI_CODING_AGENT_DIR`, explicit extension paths, and explicit session storage
+allow managed state to be scoped. Project discovery also needs a policy: changing
+HOME alone does not prevent `.pi/settings.json` or project MCP config from loading.
+The current `pi-mcp-adapter` additionally supports `createMcpAdapter({config})` and
+runtime MCP registration; its in-memory configuration avoids ambient file merging.
+The integration should use that boundary or an equally explicit pinned mechanism.
+
+Configuration isolation is not a security sandbox. Extensions and installer scripts
+can execute code with the process's permissions; the system must not promise that
+arbitrary packages only write managed directories. Keep native setup directories
+available after a process exits, and distinguish terminate from destructive purge.
+Secrets and transcripts require private storage. Do not put secret values in public
+lifecycle events or effective-configuration responses; ACP payloads/logs themselves
+can contain sensitive data and need access controls and an at-rest policy.
+
+## Remaining pre-production gates
+
+Content transport is executable; the public ACP HTTP binding, reset lifecycle,
+configuration materializer, and their shared acceptance tests are not. Existing
+crash/replay tests must stay strict when adding recovery. Also still required:
+auth/session authorization, writer ownership, bounded retention/backpressure,
+expired-cursor recovery, and real proxy/suspend testing.
+
+## Sources
+
+- [ACP session setup, including load and resume](https://agentclientprotocol.com/protocol/v1/session-setup)
+- [Resume stabilization](https://agentclientprotocol.com/rfds/session-resume)
+- [ACP content blocks](https://agentclientprotocol.com/protocol/v1/content)
+- [Remote transport proposal and deferred replay guarantees](https://agentclientprotocol.com/rfds/streamable-http-websocket-transport)
+- [Pi adapter restores a specific session file](https://github.com/svkozak/pi-acp/blob/d1cffc047ab37a096ee70ca39cfc1de463db8d12/src/acp/agent.ts#L180-L226)
+- [Codex adapter uses threadResume for resume/load](https://github.com/agentclientprotocol/codex-acp/blob/061f9a4a2e463a220d7a3ab2ae5e9732837085ef/src/CodexAcpClient.ts#L530-L605)
+- [Claude adapter distinguishes resume and history load](https://github.com/zed-industries/claude-agent-acp/blob/3e23c5b960b66a6d2c892e7524c952e731c076a7/src/acp-agent.ts#L2139-L2166)
+- [Pi MCP programmatic configuration and runtime registration](https://github.com/nicobailon/pi-mcp-adapter/blob/8243eba3421e301c88c047444f34ab7d5d57163e/index.ts#L1343-L1378)
+- [Gemini native session persistence and exact-ID resume](https://geminicli.com/docs/cli/session-management/)

--- a/server/experiments/agenttransport/README.md
+++ b/server/experiments/agenttransport/README.md
@@ -27,6 +27,7 @@ calls or provider credentials are needed for the deterministic gates.
 | Permission | `TestDeterministicACP/permission-detach-and-retry` | Pending request survives detach; only an offered `allow_once` option is selected; duplicate answers have one effect and conflicting answers fail. |
 | Cancellation | `TestDeterministicACP/cancel-pending-permission` | Cancel while approval is pending, retry cancellation, execute no tool, clear the pending request. |
 | Agent crash | `TestDeterministicACP/agent-crash-fences-session` | Kill the ACP process mid-tool; expose `uncertain`, do not resend the prompt, reject new work in that session. |
+| Crash during permission | `TestDeterministicACP/agent-crash-during-permission` | Kill the agent while approval is pending; unblock the permission wait, expose `uncertain`, remove the stale request, and execute no tool. |
 | Service restart | `TestJournalRecoveryAfterProcessKill` | Reopen after kill at accepted, tool-start, permission-pending, and completed boundaries. Completed stays completed; unfinished becomes uncertain. No automatic dispatch. |
 | Write failure | `TestPersistenceFailurePreventsDispatch`, `TestPermissionPersistenceFailureNeverApproves` | A failed journal write cannot acknowledge/dispatch a prompt or release an approval. The runtime becomes unavailable. |
 | Journal integrity | `TestJournalLockAndTornTail` | One owner, repair incomplete final records, reject complete corrupt records. |
@@ -34,9 +35,9 @@ calls or provider credentials are needed for the deterministic gates.
 | Cursor validation | `TestInvalidReplayCursor` | Malformed/negative cursors return 400; future cursors return 409. |
 | MCP fixture | `TestMCPToolBarrier` | MCP initialization, tool discovery, invocation, counted barrier, and release work independently of the agent. |
 
-The first five cases are exported through `acceptance.Run`, `RunPermissions`,
-and `RunCrash`. The **same assertions** run against real harnesses through
-`TestRealHarness`; each subtest gets a new agent and workspace.
+The first six cases are exported through `acceptance.Run`, `RunPermissions`,
+`RunCrash`, and `RunPermissionCrash`. The **same assertions** run against real
+harnesses through `TestRealHarness`; each subtest gets a new agent and workspace.
 
 ## Run a real harness
 
@@ -127,8 +128,9 @@ ACP v1's prompt response means completion, not acceptance. The service's
 sends `session/cancel` and waits up to five seconds for completion before killing
 the agent process group. A forced kill fails the harness cancellation gate; it
 is not silently counted as native cancellation support. It does not reuse an
-agent that failed to stop. It does not advertise client filesystem or terminal delegation; execution remains local
-to the agent. Unsupported server requests receive an explicit protocol error.
+agent that failed to stop. It does not advertise client filesystem or terminal
+delegation; execution remains local to the agent. Unsupported server requests
+receive an explicit protocol error.
 
 `FileStore` appends and fsyncs before publishing events or releasing work. On
 restart, a nonterminal operation becomes `uncertain`, its old permission requests
@@ -157,7 +159,7 @@ Self-contained assignment brief (substitute one harness):
 > named harness's configuration/wrapper/tests, on a separate branch. Record actual
 > binary/package versions and initialization capabilities. Use approved existing
 > credentials; if missing, report BLOCKED rather than creating accounts or storing
-> credentials. Run the five shared real-harness cases, including a separate
+> credentials. Run the six shared real-harness cases, including a separate
 > permission-required configuration. Do not weaken assertions, auto-approve
 > permissions in the permission suite, change common wire semantics, or silently
 > accept ignored MCP/settings. Fix harness-specific plumbing or report the precise

--- a/server/experiments/agenttransport/README.md
+++ b/server/experiments/agenttransport/README.md
@@ -4,6 +4,10 @@ An isolated **custom POST + SSE** session-service experiment and a reusable ACP 
 stdio harness driver. No production route is registered and no coding agent is
 installed automatically. Deterministic tests passing is not a real-harness pass.
 
+**Fan-out is on hold pending design alignment.** [DESIGN.md](DESIGN.md) proposes
+an ACP-first public binding, exact-session reset/resume, and scoped configuration.
+The REST routes below remain acceptance fixtures, not the proposed public API.
+
 ## Run the shared gates
 
 From `server/`:
@@ -34,6 +38,8 @@ calls or provider credentials are needed for the deterministic gates.
 | Retry contention | `TestConcurrentRetriesAndPayloadConflict` | Twenty concurrent duplicate submissions execute once; changed payload with the same ID is rejected. |
 | Cursor validation | `TestInvalidReplayCursor` | Malformed/negative cursors return 400; future cursors return 409. |
 | MCP fixture | `TestMCPToolBarrier` | MCP initialization, tool discovery, invocation, counted barrier, and release work independently of the agent. |
+| Content fidelity | `TestContentThroughHTTPACPAndJournal` | Text, image, audio, resource-link, embedded text/blob, annotations, and metadata survive HTTP, ACP, SSE, and journal recovery. Includes content above 64 KiB and preserved prompt results. |
+| Content admission | `TestContentRetryAndOwnership`, `TestInvalidPromptContent`, `TestPromptSizeLimit`, `TestUnsupportedContentDoesNotDispatch` | Formatting-insensitive retries, changed-content conflicts, owned buffers, bounded content, and capability rejection before dispatch. |
 
 The first six cases are exported through `acceptance.Run`, `RunPermissions`,
 `RunCrash`, and `RunPermissionCrash`. The **same assertions** run against real
@@ -111,7 +117,7 @@ evidence directory is configured, temporary evidence is deleted after the test.
 
 | Endpoint | Meaning |
 | --- | --- |
-| `POST /commands` | `{id,prompt}`; durable acceptance before local dispatch. Reusing an ID with a different payload returns 409. Returns `{id,state}` with 202, including for identical retries. |
+| `POST /commands` | `{id,prompt}` where `prompt` is an ACP content-block array, not a string; durable acceptance before local dispatch. Reusing an ID with a different payload returns 409. Returns `{id,state}` with 202, including for identical retries. |
 | `POST /permissions` | `{id,operationId,requestId,optionId}`; offered choices only, durable decision before releasing the blocked agent. Retry the same control ID/body. |
 | `POST /cancel` | `{id,operationId}`; durable cancellation request before signalling the turn. Retry the same control ID/body. Cancellation does not undo prior side effects. |
 | `GET /events` | SSE `id` equals event `sequence`. `Last-Event-ID` is the last **applied** event. Replay is exclusive of that cursor and seamlessly continues with live events. |
@@ -120,7 +126,11 @@ evidence directory is configured, temporary evidence is deleted after the test.
 Operation IDs and control IDs are stable application identities, not ACP JSON-RPC
 request IDs. There is one active turn per session. Admission checks happen after
 idempotency checks. HTTP detach never cancels the turn or restarts ACP. Original
-ACP `session/update` messages are retained as JSON payloads, not flattened text.
+ACP `session/update` messages and prompt results/errors are retained as JSON payloads,
+not flattened text. Encoded content arrays are limited to 4 MiB. Image, audio, and
+embedded-resource prompts require the agent's corresponding capability. A basic
+request is `{"id":"turn-1","prompt":[{"type":"text","text":"inspect the project"}]}`.
+Old string-prompt journals are not migrated; use a new evidence directory.
 
 ACP v1's prompt response means completion, not acceptance. The service's
 `accepted` event means the session service has journaled the command; it does
@@ -142,7 +152,8 @@ a fresh session explicitly instead of retrying effects automatically.
 
 ## Parallel assignment contract
 
-The common test driver is ready for per-harness compatibility work. Each agent
+The common test driver supplies the current gates; launch remains paused until
+the proposed lifecycle/configuration boundary is agreed. Each agent
 owns one harness adapter/configuration and its tests, **not** a new transport.
 
 | Harness | Starting integration | Additional acceptance work |
@@ -163,8 +174,10 @@ Self-contained assignment brief (substitute one harness):
 > permission-required configuration. Do not weaken assertions, auto-approve
 > permissions in the permission suite, change common wire semantics, or silently
 > accept ignored MCP/settings. Fix harness-specific plumbing or report the precise
-> incompatibility. Separately validate configuration changes, native session
-> history restoration, and (for Pi) one installed extension tool. Keep evidence
+> incompatibility. Separately validate supported prompt content, configuration changes, exact-ID native
+> session restoration in a fresh process (without automatically continuing tools),
+> and (for Pi) one installed extension tool. Record any ACP-to-native ID mapping,
+> persistent state directories, and whether config writes affect another session. Keep evidence
 > private, scrub logs before sharing, and report each case PASS / FAIL /
 > UNSUPPORTED / BLOCKED with evidence paths and operation IDs. SKIP is not PASS.
 > Return a PR, configuration instructions, capability matrix, and explicit

--- a/server/experiments/agenttransport/README.md
+++ b/server/experiments/agenttransport/README.md
@@ -125,8 +125,9 @@ ACP v1's prompt response means completion, not acceptance. The service's
 `accepted` event means the session service has journaled the command; it does
 **not** claim the agent has already accepted it. On cancellation the ACP driver
 sends `session/cancel` and waits up to five seconds for completion before killing
-the agent process group. It does not reuse an agent that failed to stop. It does
-not advertise client filesystem or terminal delegation; execution remains local
+the agent process group. A forced kill fails the harness cancellation gate; it
+is not silently counted as native cancellation support. It does not reuse an
+agent that failed to stop. It does not advertise client filesystem or terminal delegation; execution remains local
 to the agent. Unsupported server requests receive an explicit protocol error.
 
 `FileStore` appends and fsyncs before publishing events or releasing work. On

--- a/server/experiments/agenttransport/README.md
+++ b/server/experiments/agenttransport/README.md
@@ -1,0 +1,138 @@
+# Agent transport acceptance experiment
+
+This is a runnable proof of a **custom POST + SSE reconnect contract**, not an
+ACP HTTP implementation or a production API. Nothing is registered in the image
+server, and no agent or extension is installed by this experiment.
+
+## Run
+
+From `server/`:
+
+```sh
+go test -race -count=100 ./experiments/agenttransport
+go vet ./experiments/agenttransport
+```
+
+Tests use actual loopback HTTP/TCP connections, not only recorder-based handler
+calls. A deterministic runner emits output around a synchronization barrier and
+counts executions. No provider credentials or model calls are required.
+
+## What this establishes
+
+| ID | Executable test | Assertion |
+| --- | --- | --- |
+| T01 | `TestDisconnectRetryAndReplay` | Disconnect mid-turn, retry the prompt, reconnect from the last applied event: one execution, ordered missing output, terminal completion. Retry after completion remains harmless. |
+| T02 | `TestLostSubmitResponseDoesNotRepeatExecution` | Send a prompt over TCP, discard its HTTP acknowledgement, close the connection, retry: one execution and complete replay. |
+| T03 | `TestConcurrentRetriesAndPayloadConflict` | Twenty concurrent submissions with one ID execute once; the same ID with a different prompt returns 409. |
+| T04 | `TestInvalidReplayCursor` | Negative/malformed cursors return 400; a cursor ahead of the log returns 409 instead of silently losing data. |
+
+The experiment validates **client connection loss while the runtime remains
+alive**. It does not validate restart durability, real ACP adapters, remote
+proxies, image suspension, authentication, or loss of the underlying machine.
+It does not benchmark SSE against WebSocket; both can implement this contract.
+
+## Contract under test
+
+A reference runtime represents exactly one session. Its lifetime is independent
+of HTTP requests. The test shuts it down explicitly.
+
+- `POST /commands`: `{ "id": "client-generated-stable-id", "prompt": "..." }`.
+  Returns 202 with `{ "id": "...", "state": "running|completed|failed" }`.
+  Reuse an ID only for an identical command. The reference retains IDs for its
+  entire lifetime. Operation identity is separate from an ACP JSON-RPC request ID.
+- `GET /events`: SSE with `Last-Event-ID` set to the last **applied** sequence
+  number (0 starts from the beginning). Each event has an SSE `id` matching its
+  JSON `sequence`, plus `operationId`, `kind`, and optional `text`.
+- Replay is exclusive of the supplied sequence. The log is the source for both
+  replay and live delivery; subscription registration and log snapshots are
+  synchronized so an event cannot disappear between replay and live delivery.
+- `accepted` precedes execution. Exactly one terminal event follows a runner
+  invocation. A broken HTTP response or stream does not cancel the invocation.
+- The receiver must apply events in order and ignore already-applied sequences.
+  Updating a durable cursor before applying an event is unsafe.
+
+The runner boundary is intentionally smaller than ACP. A production adapter must
+translate ACP prompt/update/completion messages into the session service, while
+retaining the original ACP payloads rather than flattening them to text as this
+fixture does. ACP v1 prompt responses mean completion, not immediate acceptance;
+the service must track submission separately without misreporting agent acceptance.
+
+## Required gates before shipping
+
+Unchecked gates are **not implemented**, not implicitly passing.
+
+### Transport/session service (shared by all harnesses)
+
+| ID | Pending acceptance case | Required result |
+| --- | --- | --- |
+| T05 | Reconnect repeatedly during high-volume output; slow consumer; replay cursor expires | No silent gaps or unbounded memory growth; explicit expired-cursor response and snapshot/reconciliation path. |
+| T06 | Disconnect while permission is pending; retry its answer; answer from two clients | Same unresolved request on reconnect; one decision applied; conflicting answers rejected; never auto-approve. |
+| T07 | Cancel during disconnection; lose cancel acknowledgement; retry | Cancellation has a stable operation ID and observable outcome; disconnect alone never cancels. |
+| T08 | Restart service at each command acceptance/dispatch/result boundary | Persist before acknowledging; completed operations deduplicate; ambiguous dispatch is reported, never blindly retried. |
+| T09 | Restart during event append/delivery; reconnect with stale cursor | Durable ordered replay or explicit recovery failure; no claim that conversation history is a complete event log. |
+| T10 | Expired credentials, another session's IDs/cursors, superseded writer | Reauthenticate and authorize every attach/command; no cross-session data or competing command ownership. |
+| T11 | Half-open connection, proxy timeout, suspend/resume | Bounded detection and backoff; keepalive; attach to the same live runtime without resetting ACP. |
+
+T08 cannot promise exactly-once arbitrary shell effects. There is a crash window
+between handing a command to an external agent and durably recording that fact.
+The service must reconcile using agent evidence or expose an uncertain outcome.
+A deduplication map alone does not close that window.
+
+### Harness compatibility (run separately for every pinned harness version)
+
+| ID | Case | Required result |
+| --- | --- | --- |
+| H01 | Initialize, create session, prompt, output/tool updates, completion | Correct ACP capabilities and event mapping; original payloads retained. |
+| H02 | Repeat T01/T02 with a real harness and an instrumented tool | One adapter dispatch; record tool execution counts and ordered replay. Control tool retries explicitly so model behavior is not confused with transport duplication. |
+| H03 | Detach/reattach during tool execution and permission wait | Same live agent process and ACP conversation; no new prompt or hidden auto-approval. |
+| H04 | Agent crash and session restoration | Clear distinction between history restoration and continuation of in-flight work; unsupported recovery is explicit. |
+| H05 | MCP tool, configuration, and supported extensions | An actual tool invocation works; unsupported settings are rejected rather than silently ignored. |
+
+## Bounded harness assignments
+
+Each assignment should implement an adapter and run the shared tests, not invent
+another network transport, cursor format, or retry policy. Do not mark a harness
+supported based only on the deterministic runner passing.
+
+| Harness | Starting point | Additional requirement |
+| --- | --- | --- |
+| Pi | `pi-acp` wrapping `pi --mode rpc` | Verify MCP configuration is actually forwarded; install a pinned tool extension and invoke it. Report extension UI/command limitations explicitly. |
+| Codex | `codex-acp` wrapping Codex App Server | Verify approvals, sandbox settings, MCP, and native session recovery with pinned adapter/CLI versions. |
+| Claude | `claude-agent-acp` using Claude Agent SDK | Verify permissions, MCP, and recovery; identify SDK behavior separately from interactive CLI behavior. |
+| Gemini | Gemini CLI ACP mode | Verify advertised capabilities, permission handling, MCP, and session restoration against the pinned release. |
+
+Common assignment brief:
+
+> Implement only the named harness adapter against the shared session-service
+> contract. Start by recording exact harness/adapter versions and initialization
+> capabilities. Use a temporary workspace and scoped test credentials. Keep ACP
+> connected locally while the network client is detached. Run H01-H05 and the
+> shared transport tests; report each as PASS, FAIL, or UNSUPPORTED with logs and
+> operation/event IDs. Do not log credentials, run destructive commands, or
+> silently convert unsupported behavior into success. Deliver tests, adapter
+> code, capability matrix, and recovery limitations. Do not change the shared
+> protocol without raising the mismatch first.
+
+Before dispatching those assignments, implement the shared session service and
+its test-driver boundary for controlled tool barriers, permission decisions,
+process identity, and crash injection. The current runner fixture is not that
+real-agent driver yet.
+
+## Deliberate prototype limits
+
+The reference uses an unbounded in-memory log and operation map, accepts only
+text, and has no authentication, session routing, heartbeat, write deadline,
+permission flow, cancellation API, or admission limit. **Do not expose it to
+untrusted callers or register it in the production router.** Shutdown assumes
+runners honor context cancellation. These limits keep the experiment focused on
+network loss rather than presenting an incomplete service as production-ready.
+
+## Protocol references
+
+- [ACP v1 transports](https://agentclientprotocol.com/protocol/v1/transports)
+- [HTTP/WebSocket proposal](https://agentclientprotocol.com/rfds/streamable-http-websocket-transport)
+- [ACP v1 session setup](https://agentclientprotocol.com/protocol/v1/session-setup)
+
+The remote transport proposal defers event replay and resumability; this
+experiment does not claim conformance to that draft. Keep the network binding
+versioned and separate from ACP adapter behavior.

--- a/server/experiments/agenttransport/README.md
+++ b/server/experiments/agenttransport/README.md
@@ -1,138 +1,194 @@
-# Agent transport acceptance experiment
+# Agent transport acceptance suite
 
-This is a runnable proof of a **custom POST + SSE reconnect contract**, not an
-ACP HTTP implementation or a production API. Nothing is registered in the image
-server, and no agent or extension is installed by this experiment.
+An isolated **custom POST + SSE** session-service experiment and a reusable ACP v1
+stdio harness driver. No production route is registered and no coding agent is
+installed automatically. Deterministic tests passing is not a real-harness pass.
 
-## Run
+## Run the shared gates
 
 From `server/`:
 
 ```sh
-go test -race -count=100 ./experiments/agenttransport
-go vet ./experiments/agenttransport
+go test -race -count=30 ./experiments/agenttransport/...
+go vet ./experiments/agenttransport/...
 ```
 
-Tests use actual loopback HTTP/TCP connections, not only recorder-based handler
-calls. A deterministic runner emits output around a synchronization barrier and
-counts executions. No provider credentials or model calls are required.
+The existing server unit-test target includes these packages. Tests use actual
+HTTP/TCP connections, a separate ACP subprocess, and on-disk journals. Recovery
+tests kill a separate process instead of gracefully shutting it down. No model
+calls or provider credentials are needed for the deterministic gates.
 
-## What this establishes
+## Executable coverage
 
-| ID | Executable test | Assertion |
+| Gate | Test | Required result |
 | --- | --- | --- |
-| T01 | `TestDisconnectRetryAndReplay` | Disconnect mid-turn, retry the prompt, reconnect from the last applied event: one execution, ordered missing output, terminal completion. Retry after completion remains harmless. |
-| T02 | `TestLostSubmitResponseDoesNotRepeatExecution` | Send a prompt over TCP, discard its HTTP acknowledgement, close the connection, retry: one execution and complete replay. |
-| T03 | `TestConcurrentRetriesAndPayloadConflict` | Twenty concurrent submissions with one ID execute once; the same ID with a different prompt returns 409. |
-| T04 | `TestInvalidReplayCursor` | Negative/malformed cursors return 400; a cursor ahead of the log returns 409 instead of silently losing data. |
+| Disconnect | `TestDeterministicACP/disconnect-mid-tool` | Detach at a counted tool barrier, retry, finish while no stream is attached, replay the complete missing suffix. Same process, one dispatch, one tool invocation. |
+| Lost acknowledgement | `TestDeterministicACP/lost-prompt-acknowledgement` | Send over TCP without reading its response; retry without executing twice. |
+| Permission | `TestDeterministicACP/permission-detach-and-retry` | Pending request survives detach; only an offered `allow_once` option is selected; duplicate answers have one effect and conflicting answers fail. |
+| Cancellation | `TestDeterministicACP/cancel-pending-permission` | Cancel while approval is pending, retry cancellation, execute no tool, clear the pending request. |
+| Agent crash | `TestDeterministicACP/agent-crash-fences-session` | Kill the ACP process mid-tool; expose `uncertain`, do not resend the prompt, reject new work in that session. |
+| Service restart | `TestJournalRecoveryAfterProcessKill` | Reopen after kill at accepted, tool-start, permission-pending, and completed boundaries. Completed stays completed; unfinished becomes uncertain. No automatic dispatch. |
+| Write failure | `TestPersistenceFailurePreventsDispatch`, `TestPermissionPersistenceFailureNeverApproves` | A failed journal write cannot acknowledge/dispatch a prompt or release an approval. The runtime becomes unavailable. |
+| Journal integrity | `TestJournalLockAndTornTail` | One owner, repair incomplete final records, reject complete corrupt records. |
+| Retry contention | `TestConcurrentRetriesAndPayloadConflict` | Twenty concurrent duplicate submissions execute once; changed payload with the same ID is rejected. |
+| Cursor validation | `TestInvalidReplayCursor` | Malformed/negative cursors return 400; future cursors return 409. |
+| MCP fixture | `TestMCPToolBarrier` | MCP initialization, tool discovery, invocation, counted barrier, and release work independently of the agent. |
 
-The experiment validates **client connection loss while the runtime remains
-alive**. It does not validate restart durability, real ACP adapters, remote
-proxies, image suspension, authentication, or loss of the underlying machine.
-It does not benchmark SSE against WebSocket; both can implement this contract.
+The first five cases are exported through `acceptance.Run`, `RunPermissions`,
+and `RunCrash`. The **same assertions** run against real harnesses through
+`TestRealHarness`; each subtest gets a new agent and workspace.
 
-## Contract under test
+## Run a real harness
 
-A reference runtime represents exactly one session. Its lifetime is independent
-of HTTP requests. The test shuts it down explicitly.
+1. Install pinned harness and ACP adapter versions. Authenticate separately using
+   an approved provider credential or existing CLI login. Do not embed secrets
+   in JSON, prompts, branches, or committed files.
+2. Create a private configuration, for example `/tmp/harness.json`:
 
-- `POST /commands`: `{ "id": "client-generated-stable-id", "prompt": "..." }`.
-  Returns 202 with `{ "id": "...", "state": "running|completed|failed" }`.
-  Reuse an ID only for an identical command. The reference retains IDs for its
-  entire lifetime. Operation identity is separate from an ACP JSON-RPC request ID.
-- `GET /events`: SSE with `Last-Event-ID` set to the last **applied** sequence
-  number (0 starts from the beginning). Each event has an SSE `id` matching its
-  JSON `sequence`, plus `operationId`, `kind`, and optional `text`.
-- Replay is exclusive of the supplied sequence. The log is the source for both
-  replay and live delivery; subscription registration and log snapshots are
-  synchronized so an event cannot disappear between replay and live delivery.
-- `accepted` precedes execution. Exactly one terminal event follows a runner
-  invocation. A broken HTTP response or stream does not cancel the invocation.
-- The receiver must apply events in order and ignore already-applied sequences.
-  Updating a durable cursor before applying an event is unsafe.
+```json
+{
+  "harness": "replace-with-harness-name",
+  "harnessVersion": "replace-with-verified-version",
+  "adapterVersion": "replace-with-verified-version",
+  "acp": {
+    "command": "/absolute/path/to/pinned-acp-adapter",
+    "args": [],
+    "env": [],
+    "inheritEnv": [],
+    "setup": []
+  }
+}
+```
 
-The runner boundary is intentionally smaller than ACP. A production adapter must
-translate ACP prompt/update/completion messages into the session service, while
-retaining the original ACP payloads rather than flattening them to text as this
-fixture does. ACP v1 prompt responses mean completion, not immediate acceptance;
-the service must track submission separately without misreporting agent acceptance.
+3. Run:
 
-## Required gates before shipping
+```sh
+AGENT_ACCEPTANCE_CONFIG=/tmp/harness.json \
+AGENT_ACCEPTANCE_EVIDENCE_DIR=/tmp/harness-evidence \
+go test -race -v -count=1 ./experiments/agenttransport/harness \
+  -run '^TestRealHarness$' -timeout=20m
+```
 
-Unchecked gates are **not implemented**, not implicitly passing.
+The harness suite builds `cmd/agent-probe` and injects the `acceptance-probe` stdio
+MCP server through `session/new.mcpServers`. Its `checkpoint` tool records each
+invocation, blocks until the test releases it, then returns a completion message.
+The runner must actually invoke the tool; missing MCP plumbing times out and fails
+rather than being counted as support.
 
-### Transport/session service (shared by all harnesses)
+The default `acp` configuration must permit that test tool without interaction.
+Add a full **separate** `permissionACP` configuration object to test approval
+behavior; it must require approval for the checkpoint, not bypass it. If omitted,
+permission tests report **SKIP / NOT VALIDATED**, not a compatibility pass.
 
-| ID | Pending acceptance case | Required result |
+Supported configuration details:
+
+- `authMethod` optionally invokes ACP `authenticate` after initialization. This
+  driver does not implement interactive terminal login. Pre-authentication or a
+  supported noninteractive agent auth method is required.
+- `setup` contains `{ "method": "session/set_config_option", "params": {...} }`
+  calls; `session/set_mode` and `session/set_model` are also accepted. The driver
+  injects `sessionId`. Unsupported setup methods fail; agent errors are surfaced.
+- `{workspace}`, `{probeDir}`, and `{probeCommand}` expand in command, arguments,
+  and explicit environment entries. A small wrapper can prepare harness-specific
+  configuration before exec, without modifying the shared suite. Each workspace
+  is a child directory separate from journal/probe evidence.
+- Only basic process environment (PATH, HOME, USER, LANG, TMPDIR, TERM and certificate
+  paths) is inherited by default. `inheritEnv` explicitly names additional variables,
+  such as a provider key; values are looked up at runtime and never printed by the
+  driver. `env` is for explicit nonsecret configuration. Existing HOME-based CLI
+  credentials remain accessible; this is a test driver, not an agent sandbox.
+- Each startup and test body has a two-minute bound. Unknown configuration fields
+  are rejected. Versions in the config are declarations: attach actual version
+  command output separately rather than treating these strings as verification.
+
+Evidence directories contain `capabilities.json`, `events.jsonl`, `agent.stderr`,
+and the tool invocation counter/release marker. Treat all evidence as private:
+agent output and logs can contain sensitive information. Do not commit it. If no
+evidence directory is configured, temporary evidence is deleted after the test.
+
+## Contract owned by the shared session service
+
+| Endpoint | Meaning |
+| --- | --- |
+| `POST /commands` | `{id,prompt}`; durable acceptance before local dispatch. Reusing an ID with a different payload returns 409. Returns `{id,state}` with 202, including for identical retries. |
+| `POST /permissions` | `{id,operationId,requestId,optionId}`; offered choices only, durable decision before releasing the blocked agent. Retry the same control ID/body. |
+| `POST /cancel` | `{id,operationId}`; durable cancellation request before signalling the turn. Retry the same control ID/body. Cancellation does not undo prior side effects. |
+| `GET /events` | SSE `id` equals event `sequence`. `Last-Event-ID` is the last **applied** event. Replay is exclusive of that cursor and seamlessly continues with live events. |
+| `GET /snapshot` | Current sequence, operation states, and unresolved permissions from one synchronized snapshot. It is not a replacement for conversation replay. |
+
+Operation IDs and control IDs are stable application identities, not ACP JSON-RPC
+request IDs. There is one active turn per session. Admission checks happen after
+idempotency checks. HTTP detach never cancels the turn or restarts ACP. Original
+ACP `session/update` messages are retained as JSON payloads, not flattened text.
+
+ACP v1's prompt response means completion, not acceptance. The service's
+`accepted` event means the session service has journaled the command; it does
+**not** claim the agent has already accepted it. On cancellation the ACP driver
+sends `session/cancel` and waits up to five seconds for completion before killing
+the agent process group. It does not reuse an agent that failed to stop. It does
+not advertise client filesystem or terminal delegation; execution remains local
+to the agent. Unsupported server requests receive an explicit protocol error.
+
+`FileStore` appends and fsyncs before publishing events or releasing work. On
+restart, a nonterminal operation becomes `uncertain`, its old permission requests
+cease to be actionable, and new commands are fenced off. Retry returns the
+existing state. This is deliberately conservative: a crash between dispatch and
+recording its result cannot promise exactly-once external shell effects. This
+experiment has no reconciliation/unfence endpoint; inspect the outcome and create
+a fresh session explicitly instead of retrying effects automatically.
+
+## Parallel assignment contract
+
+The common test driver is ready for per-harness compatibility work. Each agent
+owns one harness adapter/configuration and its tests, **not** a new transport.
+
+| Harness | Starting integration | Additional acceptance work |
 | --- | --- | --- |
-| T05 | Reconnect repeatedly during high-volume output; slow consumer; replay cursor expires | No silent gaps or unbounded memory growth; explicit expired-cursor response and snapshot/reconciliation path. |
-| T06 | Disconnect while permission is pending; retry its answer; answer from two clients | Same unresolved request on reconnect; one decision applied; conflicting answers rejected; never auto-approve. |
-| T07 | Cancel during disconnection; lose cancel acknowledgement; retry | Cancellation has a stable operation ID and observable outcome; disconnect alone never cancels. |
-| T08 | Restart service at each command acceptance/dispatch/result boundary | Persist before acknowledging; completed operations deduplicate; ambiguous dispatch is reported, never blindly retried. |
-| T09 | Restart during event append/delivery; reconnect with stale cursor | Durable ordered replay or explicit recovery failure; no claim that conversation history is a complete event log. |
-| T10 | Expired credentials, another session's IDs/cursors, superseded writer | Reauthenticate and authorize every attach/command; no cross-session data or competing command ownership. |
-| T11 | Half-open connection, proxy timeout, suspend/resume | Bounded detection and backoff; keepalive; attach to the same live runtime without resetting ACP. |
+| Pi | `pi-acp` wrapping `pi --mode rpc` | Make session MCP configuration effective (the upstream adapter currently documents that it does not forward it). Install a pinned tool extension and prove an invocation. Report unsupported extension UI/commands. |
+| Codex | `codex-acp` wrapping Codex App Server | Pin both versions; test model/approval/sandbox configuration, MCP, and the distinction between native history restoration and interrupted work. |
+| Claude | `claude-agent-acp` using Claude Agent SDK | Pin adapter/SDK; test MCP and approval settings. Identify SDK behavior separately from the interactive CLI. |
+| Gemini | Gemini CLI ACP mode | Pin release; verify advertised capabilities, MCP, permission mode, and native session-restoration support. |
 
-T08 cannot promise exactly-once arbitrary shell effects. There is a crash window
-between handing a command to an external agent and durably recording that fact.
-The service must reconcile using agent evidence or expose an uncertain outcome.
-A deduplication map alone does not close that window.
+Self-contained assignment brief (substitute one harness):
 
-### Harness compatibility (run separately for every pinned harness version)
+> Use `kernel/kernel-images`, branch `hypeship/agent-reconnect-acceptance`, as the
+> shared baseline. Read `server/experiments/agenttransport/README.md`. Own only the
+> named harness's configuration/wrapper/tests, on a separate branch. Record actual
+> binary/package versions and initialization capabilities. Use approved existing
+> credentials; if missing, report BLOCKED rather than creating accounts or storing
+> credentials. Run the five shared real-harness cases, including a separate
+> permission-required configuration. Do not weaken assertions, auto-approve
+> permissions in the permission suite, change common wire semantics, or silently
+> accept ignored MCP/settings. Fix harness-specific plumbing or report the precise
+> incompatibility. Separately validate configuration changes, native session
+> history restoration, and (for Pi) one installed extension tool. Keep evidence
+> private, scrub logs before sharing, and report each case PASS / FAIL /
+> UNSUPPORTED / BLOCKED with evidence paths and operation IDs. SKIP is not PASS.
+> Return a PR, configuration instructions, capability matrix, and explicit
+> recovery limits. Escalate shared-driver defects instead of forking its protocol.
 
-| ID | Case | Required result |
-| --- | --- | --- |
-| H01 | Initialize, create session, prompt, output/tool updates, completion | Correct ACP capabilities and event mapping; original payloads retained. |
-| H02 | Repeat T01/T02 with a real harness and an instrumented tool | One adapter dispatch; record tool execution counts and ordered replay. Control tool retries explicitly so model behavior is not confused with transport duplication. |
-| H03 | Detach/reattach during tool execution and permission wait | Same live agent process and ACP conversation; no new prompt or hidden auto-approval. |
-| H04 | Agent crash and session restoration | Clear distinction between history restoration and continuation of in-flight work; unsupported recovery is explicit. |
-| H05 | MCP tool, configuration, and supported extensions | An actual tool invocation works; unsupported settings are rejected rather than silently ignored. |
+## Still not a production service
 
-## Bounded harness assignments
+Ready for harness fan-out does **not** mean ready to expose `/agent`:
 
-Each assignment should implement an adapter and run the shared tests, not invent
-another network transport, cursor format, or retry policy. Do not mark a harness
-supported based only on the deterministic runner passing.
+- The journal and in-memory replay index are unbounded. Retention, compaction,
+  expired-cursor recovery, storage quotas, and load/slow-consumer tests remain.
+- No endpoint authentication, tenant routing, credential refresh, multi-client
+  writer ownership, or hardened package/extension installation is implemented.
+- SSE has one-second keepalives and five-second write deadlines, but no remote
+  proxy, HTTP/2, half-open network, or suspend/restore validation has been run.
+- Durability covers surviving local storage and process kill, not disk/host loss
+  or power-loss guarantees on every filesystem. Shared-disk ownership uses a local
+  file lock; this is not distributed fencing.
+- The ACP driver is intentionally v1-only and single-session. Background work,
+  native agent resume, subscription auth UX, richer client capabilities, and
+  agent-specific extensions require separate evidence. The fixture's permission
+  and MCP implementations are test-only, not complete SDKs.
 
-| Harness | Starting point | Additional requirement |
-| --- | --- | --- |
-| Pi | `pi-acp` wrapping `pi --mode rpc` | Verify MCP configuration is actually forwarded; install a pinned tool extension and invoke it. Report extension UI/command limitations explicitly. |
-| Codex | `codex-acp` wrapping Codex App Server | Verify approvals, sandbox settings, MCP, and native session recovery with pinned adapter/CLI versions. |
-| Claude | `claude-agent-acp` using Claude Agent SDK | Verify permissions, MCP, and recovery; identify SDK behavior separately from interactive CLI behavior. |
-| Gemini | Gemini CLI ACP mode | Verify advertised capabilities, permission handling, MCP, and session restoration against the pinned release. |
+No real harness is marked supported until its opt-in tests and additional
+capability checks have run. The remote ACP binding remains replaceable; this
+suite does not claim conformance to the unfinished ACP HTTP transport proposal.
 
-Common assignment brief:
-
-> Implement only the named harness adapter against the shared session-service
-> contract. Start by recording exact harness/adapter versions and initialization
-> capabilities. Use a temporary workspace and scoped test credentials. Keep ACP
-> connected locally while the network client is detached. Run H01-H05 and the
-> shared transport tests; report each as PASS, FAIL, or UNSUPPORTED with logs and
-> operation/event IDs. Do not log credentials, run destructive commands, or
-> silently convert unsupported behavior into success. Deliver tests, adapter
-> code, capability matrix, and recovery limitations. Do not change the shared
-> protocol without raising the mismatch first.
-
-Before dispatching those assignments, implement the shared session service and
-its test-driver boundary for controlled tool barriers, permission decisions,
-process identity, and crash injection. The current runner fixture is not that
-real-agent driver yet.
-
-## Deliberate prototype limits
-
-The reference uses an unbounded in-memory log and operation map, accepts only
-text, and has no authentication, session routing, heartbeat, write deadline,
-permission flow, cancellation API, or admission limit. **Do not expose it to
-untrusted callers or register it in the production router.** Shutdown assumes
-runners honor context cancellation. These limits keep the experiment focused on
-network loss rather than presenting an incomplete service as production-ready.
-
-## Protocol references
-
-- [ACP v1 transports](https://agentclientprotocol.com/protocol/v1/transports)
-- [HTTP/WebSocket proposal](https://agentclientprotocol.com/rfds/streamable-http-websocket-transport)
-- [ACP v1 session setup](https://agentclientprotocol.com/protocol/v1/session-setup)
-
-The remote transport proposal defers event replay and resumability; this
-experiment does not claim conformance to that draft. Keep the network binding
-versioned and separate from ACP adapter behavior.
+References: [ACP v1 transports](https://agentclientprotocol.com/protocol/v1/transports),
+[HTTP/WebSocket proposal](https://agentclientprotocol.com/rfds/streamable-http-websocket-transport),
+[session setup](https://agentclientprotocol.com/protocol/v1/session-setup).

--- a/server/experiments/agenttransport/acceptance/crash.go
+++ b/server/experiments/agenttransport/acceptance/crash.go
@@ -11,6 +11,35 @@ import (
 	transport "github.com/kernel/kernel-images/server/experiments/agenttransport"
 )
 
+func RunPermissionCrash(t *testing.T, factory Factory) {
+	t.Run("agent-crash-during-permission", func(t *testing.T) {
+		fixture := factory(t)
+		timeout := fixture.Timeout
+		if timeout == 0 {
+			timeout = 30 * time.Second
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		command := transport.Command{ID: "permission-crash", Prompt: fixture.Prompt}
+		data, _ := json.Marshal(command)
+		post(t, ctx, fixture.URL, data)
+		waitPermission(t, ctx, fixture.URL, command.ID)
+		fixture.Kill()
+		waitState(t, ctx, fixture.URL, command.ID, "uncertain")
+		if len(snapshot(t, ctx, fixture.URL).Permissions) != 0 {
+			t.Fatal("crashed agent left an actionable permission")
+		}
+		post(t, ctx, fixture.URL, data)
+		calls, err := fixture.Probe.Count()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if calls != 0 || fixture.Dispatches() != 1 {
+			t.Fatalf("crashed permission executed: tools=%d dispatches=%d", calls, fixture.Dispatches())
+		}
+	})
+}
+
 func RunCrash(t *testing.T, factory Factory) {
 	t.Run("agent-crash-fences-session", func(t *testing.T) {
 		fixture := factory(t)

--- a/server/experiments/agenttransport/acceptance/crash.go
+++ b/server/experiments/agenttransport/acceptance/crash.go
@@ -1,0 +1,51 @@
+package acceptance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	transport "github.com/kernel/kernel-images/server/experiments/agenttransport"
+)
+
+func RunCrash(t *testing.T, factory Factory) {
+	t.Run("agent-crash-fences-session", func(t *testing.T) {
+		fixture := factory(t)
+		timeout := fixture.Timeout
+		if timeout == 0 {
+			timeout = 30 * time.Second
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		command := transport.Command{ID: "crash-operation", Prompt: fixture.Prompt}
+		data, _ := json.Marshal(command)
+		post(t, ctx, fixture.URL, data)
+		if err := fixture.Probe.Wait(ctx); err != nil {
+			t.Fatal(err)
+		}
+		fixture.Kill()
+		waitState(t, ctx, fixture.URL, command.ID, "uncertain")
+		post(t, ctx, fixture.URL, data)
+		// A new ID cannot bypass the uncertain-outcome fence.
+		other, _ := json.Marshal(transport.Command{ID: "new-operation", Prompt: fixture.Prompt})
+		request, _ := http.NewRequestWithContext(ctx, "POST", fixture.URL+"/commands", bytes.NewReader(other))
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response.Body.Close()
+		if response.StatusCode != 409 {
+			t.Fatalf("uncertain session accepted new command: %d", response.StatusCode)
+		}
+		calls, err := fixture.Probe.Count()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if calls != 1 || fixture.Dispatches() != 1 {
+			t.Fatalf("crashed operation retried: tools=%d dispatches=%d", calls, fixture.Dispatches())
+		}
+	})
+}

--- a/server/experiments/agenttransport/acceptance/permissions.go
+++ b/server/experiments/agenttransport/acceptance/permissions.go
@@ -57,6 +57,9 @@ func RunPermissions(t *testing.T, factory Factory) {
 				control := transport.Control{ID: "cancel-1", OperationID: command.ID}
 				controlPost(t, ctx, fixture.URL, "/cancel", control, 202)
 				waitState(t, ctx, fixture.URL, command.ID, "cancelled")
+				if fixture.ForcedStops() != 0 {
+					t.Fatal("agent did not acknowledge cancellation; driver had to kill it")
+				}
 				controlPost(t, ctx, fixture.URL, "/cancel", control, 202)
 				calls, err := fixture.Probe.Count()
 				if err != nil {

--- a/server/experiments/agenttransport/acceptance/permissions.go
+++ b/server/experiments/agenttransport/acceptance/permissions.go
@@ -1,0 +1,178 @@
+package acceptance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	transport "github.com/kernel/kernel-images/server/experiments/agenttransport"
+)
+
+// RunPermissions requires a harness configured to ask permission before the
+// checkpoint. Never enable approval bypasses for this suite.
+func RunPermissions(t *testing.T, factory Factory) {
+	for _, cancelWork := range []bool{false, true} {
+		name := "permission-detach-and-retry"
+		if cancelWork {
+			name = "cancel-pending-permission"
+		}
+		t.Run(name, func(t *testing.T) {
+			fixture := factory(t)
+			timeout := fixture.Timeout
+			if timeout == 0 {
+				timeout = 30 * time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			pid := fixture.ProcessID()
+			response, scanner := stream(t, ctx, fixture.URL, 0)
+			command := transport.Command{ID: "permission-operation", Prompt: fixture.Prompt}
+			data, _ := json.Marshal(command)
+			post(t, ctx, fixture.URL, data)
+			state := waitPermission(t, ctx, fixture.URL, command.ID)
+			readThrough(t, scanner, 0, state.Sequence)
+			response.Body.Close()
+			var pending transport.PendingPermission
+			for _, request := range state.Permissions {
+				pending = request
+			}
+			calls, err := fixture.Probe.Count()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calls != 0 {
+				t.Fatal("tool ran before permission")
+			}
+			reattached := snapshot(t, ctx, fixture.URL)
+			if reattached.Permissions[pending.RequestID].RequestID != pending.RequestID {
+				t.Fatal("permission disappeared on detach")
+			}
+			if fixture.ProcessID() != pid {
+				t.Fatal("agent process changed on detach")
+			}
+			if cancelWork {
+				control := transport.Control{ID: "cancel-1", OperationID: command.ID}
+				controlPost(t, ctx, fixture.URL, "/cancel", control, 202)
+				waitState(t, ctx, fixture.URL, command.ID, "cancelled")
+				controlPost(t, ctx, fixture.URL, "/cancel", control, 202)
+				calls, err := fixture.Probe.Count()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if calls != 0 {
+					t.Fatal("cancelled tool ran")
+				}
+				end := snapshot(t, ctx, fixture.URL)
+				if len(end.Permissions) != 0 {
+					t.Fatal("cancelled permission remains pending")
+				}
+				response, resumed := stream(t, ctx, fixture.URL, state.Sequence)
+				events := readThrough(t, resumed, state.Sequence, end.Sequence)
+				response.Body.Close()
+				if len(events) == 0 || events[len(events)-1].Kind != "cancelled" {
+					t.Fatal("missing replayed cancellation")
+				}
+				return
+			}
+			var request struct {
+				Options []struct {
+					OptionID string `json:"optionId"`
+					Kind     string `json:"kind"`
+				} `json:"options"`
+			}
+			if err := json.Unmarshal(pending.Payload, &request); err != nil {
+				t.Fatal(err)
+			}
+			option := ""
+			for _, choice := range request.Options {
+				if choice.Kind == "allow_once" {
+					option = choice.OptionID
+					break
+				}
+			}
+			if option == "" {
+				t.Fatal("harness did not offer allow_once; do not silently grant broader permission")
+			}
+			if err := fixture.Probe.Release(); err != nil {
+				t.Fatal(err)
+			}
+			decision := transport.Control{ID: "decision-1", OperationID: command.ID, RequestID: pending.RequestID, OptionID: option}
+			controlPost(t, ctx, fixture.URL, "/permissions", decision, 202)
+			controlPost(t, ctx, fixture.URL, "/permissions", decision, 202)
+			conflicting := decision
+			conflicting.OptionID = "invalid-choice"
+			controlPost(t, ctx, fixture.URL, "/permissions", conflicting, 409)
+			end := waitCompleted(t, ctx, fixture.URL, command.ID)
+			response, scanner = stream(t, ctx, fixture.URL, state.Sequence)
+			events := readThrough(t, scanner, state.Sequence, end.Sequence)
+			response.Body.Close()
+			resolutions := 0
+			for _, event := range events {
+				if event.Kind == "permission_resolved" {
+					resolutions++
+				}
+			}
+			calls, err = fixture.Probe.Count()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calls != 1 || resolutions != 1 || fixture.Dispatches() != 1 {
+				t.Fatalf("tools=%d decisions=%d dispatches=%d", calls, resolutions, fixture.Dispatches())
+			}
+		})
+	}
+}
+func controlPost(t *testing.T, ctx context.Context, url, path string, c transport.Control, status int) {
+	t.Helper()
+	data, _ := json.Marshal(c)
+	request, _ := http.NewRequestWithContext(ctx, "POST", url+path, bytes.NewReader(data))
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != status {
+		t.Fatalf("%s: got %d want %d", path, response.StatusCode, status)
+	}
+}
+func waitPermission(t *testing.T, ctx context.Context, url, id string) transport.Snapshot {
+	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		state := snapshot(t, ctx, url)
+		if len(state.Permissions) == 1 {
+			return state
+		}
+		if state.Operations[id].State != "running" {
+			t.Fatalf("operation ended without permission: %+v", state.Operations[id])
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal("harness did not request permission before timeout")
+		case <-ticker.C:
+		}
+	}
+}
+func waitState(t *testing.T, ctx context.Context, url, id, want string) {
+	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		state := snapshot(t, ctx, url).Operations[id].State
+		if state == want {
+			return
+		}
+		if state != "running" && state != "cancelling" {
+			t.Fatalf("got state %s want %s", state, want)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}

--- a/server/experiments/agenttransport/acceptance/suite.go
+++ b/server/experiments/agenttransport/acceptance/suite.go
@@ -25,7 +25,7 @@ import (
 type Fixture struct {
 	URL         string
 	Probe       probe.Probe
-	Prompt      string
+	Prompt      json.RawMessage
 	Dispatches  func() int
 	ForcedStops func() int
 	ProcessID   func() int

--- a/server/experiments/agenttransport/acceptance/suite.go
+++ b/server/experiments/agenttransport/acceptance/suite.go
@@ -23,13 +23,14 @@ import (
 )
 
 type Fixture struct {
-	URL        string
-	Probe      probe.Probe
-	Prompt     string
-	Dispatches func() int
-	ProcessID  func() int
-	Kill       func()
-	Timeout    time.Duration
+	URL         string
+	Probe       probe.Probe
+	Prompt      string
+	Dispatches  func() int
+	ForcedStops func() int
+	ProcessID   func() int
+	Kill        func()
+	Timeout     time.Duration
 }
 type Factory func(*testing.T) Fixture
 

--- a/server/experiments/agenttransport/acceptance/suite.go
+++ b/server/experiments/agenttransport/acceptance/suite.go
@@ -1,0 +1,234 @@
+// Package acceptance is the shared black-box disconnect suite for harness
+// adapters. Factories provide a real HTTP endpoint and a counted tool barrier.
+package acceptance
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	transport "github.com/kernel/kernel-images/server/experiments/agenttransport"
+	"github.com/kernel/kernel-images/server/experiments/agenttransport/probe"
+)
+
+type Fixture struct {
+	URL        string
+	Probe      probe.Probe
+	Prompt     string
+	Dispatches func() int
+	ProcessID  func() int
+	Kill       func()
+	Timeout    time.Duration
+}
+type Factory func(*testing.T) Fixture
+
+// Run uses exactly the same assertions for deterministic and real ACP peers.
+// A factory must allocate a fresh agent, workspace, and journal per subtest.
+func Run(t *testing.T, factory Factory) {
+	for _, lostAck := range []bool{false, true} {
+		name := "disconnect-mid-tool"
+		if lostAck {
+			name = "lost-prompt-acknowledgement"
+		}
+		t.Run(name, func(t *testing.T) {
+			fixture := factory(t)
+			timeout := fixture.Timeout
+			if timeout == 0 {
+				timeout = 30 * time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			processID := fixture.ProcessID()
+			response, scanner := stream(t, ctx, fixture.URL, 0)
+			command := transport.Command{ID: "acceptance-operation", Prompt: fixture.Prompt}
+			data, _ := json.Marshal(command)
+			if lostAck {
+				endpoint, err := url.Parse(fixture.URL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if endpoint.Scheme != "http" {
+					t.Fatal("lost-ack injector requires a loopback HTTP test server")
+				}
+				conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", endpoint.Host)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer conn.Close()
+				if deadline, ok := ctx.Deadline(); ok {
+					_ = conn.SetDeadline(deadline)
+				}
+				if _, err := fmt.Fprintf(conn, "POST /commands HTTP/1.1\r\nHost: %s\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", endpoint.Host, len(data), data); err != nil {
+					t.Fatal(err)
+				}
+				if err := fixture.Probe.Wait(ctx); err != nil {
+					t.Fatalf("agent never invoked checkpoint: %v", err)
+				}
+				conn.Close() // No response was ever read; the client cannot know acceptance.
+			} else {
+				post(t, ctx, fixture.URL, data)
+				if err := fixture.Probe.Wait(ctx); err != nil {
+					t.Fatalf("agent never invoked checkpoint: %v", err)
+				}
+			}
+			before := snapshot(t, ctx, fixture.URL)
+			prefix := readThrough(t, scanner, 0, before.Sequence)
+			response.Body.Close()
+			if before.Operations[command.ID].State != "running" {
+				t.Fatalf("agent not running at detach: %+v", before)
+			}
+			post(t, ctx, fixture.URL, data)
+			if fixture.Dispatches() != 1 {
+				t.Fatalf("prompt dispatched %d times", fixture.Dispatches())
+			}
+			if err := fixture.Probe.Release(); err != nil {
+				t.Fatal(err)
+			}
+			// Wait for durable completion while no SSE client is attached. This proves
+			// offline output replay rather than merely reconnecting before output exists.
+			after := waitCompleted(t, ctx, fixture.URL, command.ID)
+			if fixture.ProcessID() != processID {
+				t.Fatal("detach replaced the ACP process")
+			}
+			response, resumed := stream(t, ctx, fixture.URL, before.Sequence)
+			suffix := readThrough(t, resumed, before.Sequence, after.Sequence)
+			response.Body.Close()
+			response, full := stream(t, ctx, fixture.URL, 0)
+			all := readThrough(t, full, 0, after.Sequence)
+			response.Body.Close()
+			if !reflect.DeepEqual(append(prefix, suffix...), all) {
+				t.Fatal("resumed stream differs from full replay")
+			}
+			acpEvents := 0
+			for _, event := range all {
+				if event.Kind == "acp" {
+					acpEvents++
+					if !json.Valid(event.Payload) {
+						t.Fatal("invalid preserved ACP payload")
+					}
+				}
+			}
+			if acpEvents == 0 {
+				t.Fatal("no ACP updates were preserved")
+			}
+			if all[len(all)-1].Kind != "completed" {
+				t.Fatal("missing terminal completion")
+			}
+			post(t, ctx, fixture.URL, data)
+			final := snapshot(t, ctx, fixture.URL)
+			if final.Sequence != after.Sequence {
+				t.Fatal("completed retry appended new events")
+			}
+			calls, err := fixture.Probe.Count()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calls != 1 || fixture.Dispatches() != 1 {
+				t.Fatalf("dispatches=%d tool executions=%d", fixture.Dispatches(), calls)
+			}
+			t.Logf("PASS: dispatches=1 tool_executions=1 pid=%d events=%d replayed=%d", processID, after.Sequence, len(suffix))
+		})
+	}
+}
+func post(t *testing.T, ctx context.Context, url string, data []byte) {
+	t.Helper()
+	req, _ := http.NewRequestWithContext(ctx, "POST", url+"/commands", bytes.NewReader(data))
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != 202 {
+		t.Fatalf("submit status %d", response.StatusCode)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+}
+func snapshot(t *testing.T, ctx context.Context, url string) transport.Snapshot {
+	t.Helper()
+	req, _ := http.NewRequestWithContext(ctx, "GET", url+"/snapshot", nil)
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != 200 {
+		t.Fatalf("snapshot status %d", response.StatusCode)
+	}
+	var result transport.Snapshot
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+func waitCompleted(t *testing.T, ctx context.Context, url, id string) transport.Snapshot {
+	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		state := snapshot(t, ctx, url)
+		switch state.Operations[id].State {
+		case "completed":
+			return state
+		case "failed", "cancelled", "uncertain":
+			t.Fatalf("operation ended as %s", state.Operations[id].State)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+func stream(t *testing.T, ctx context.Context, url string, cursor int) (*http.Response, *bufio.Scanner) {
+	t.Helper()
+	req, _ := http.NewRequestWithContext(ctx, "GET", url+"/events", nil)
+	req.Header.Set("Last-Event-ID", strconv.Itoa(cursor))
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { response.Body.Close() })
+	if response.StatusCode != 200 {
+		t.Fatalf("stream status %d", response.StatusCode)
+	}
+	scanner := bufio.NewScanner(response.Body)
+	scanner.Buffer(make([]byte, 4096), 16<<20)
+	return response, scanner
+}
+func readThrough(t *testing.T, scanner *bufio.Scanner, cursor, end int) []transport.Event {
+	t.Helper()
+	events := make([]transport.Event, 0, end-cursor)
+	id := ""
+	for cursor < end && scanner.Scan() {
+		if value, ok := strings.CutPrefix(scanner.Text(), "id: "); ok {
+			id = value
+		}
+		if value, ok := strings.CutPrefix(scanner.Text(), "data: "); ok {
+			var event transport.Event
+			if err := json.Unmarshal([]byte(value), &event); err != nil {
+				t.Fatal(err)
+			}
+			if event.Sequence != cursor+1 || id != strconv.Itoa(event.Sequence) {
+				t.Fatalf("gap or duplicate: cursor=%d id=%s event=%+v", cursor, id, event)
+			}
+			events = append(events, event)
+			cursor++
+			id = ""
+		}
+	}
+	if cursor != end {
+		t.Fatalf("stream ended at %d before %d: %v", cursor, end, scanner.Err())
+	}
+	return events
+}

--- a/server/experiments/agenttransport/acceptance_test.go
+++ b/server/experiments/agenttransport/acceptance_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -41,7 +42,13 @@ func setup(t *testing.T) (*controlledRunner, *httptest.Server) {
 	runner := &controlledRunner{started: make(chan struct{}), release: make(chan struct{})}
 	runtime := NewReference(runner)
 	server := httptest.NewServer(runtime)
-	t.Cleanup(func() { runtime.Close(); server.Close() })
+	t.Cleanup(func() {
+		runtime.Close()
+		server.Close()
+		if count := runner.executions.Load(); count > 1 {
+			t.Errorf("duplicate executions after draining workers: %d", count)
+		}
+	})
 	return runner, server
 }
 
@@ -78,11 +85,22 @@ func subscribe(t *testing.T, server *httptest.Server, cursor int) (*http.Respons
 
 func next(t *testing.T, scanner *bufio.Scanner) Event {
 	t.Helper()
+	sequence := 0
 	for scanner.Scan() {
+		if id, ok := strings.CutPrefix(scanner.Text(), "id: "); ok {
+			var err error
+			sequence, err = strconv.Atoi(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
 		if data, ok := strings.CutPrefix(scanner.Text(), "data: "); ok {
 			var event Event
 			if err := json.Unmarshal([]byte(data), &event); err != nil {
 				t.Fatal(err)
+			}
+			if sequence == 0 || sequence != event.Sequence {
+				t.Fatalf("SSE id %d does not match event %+v", sequence, event)
 			}
 			return event
 		}

--- a/server/experiments/agenttransport/acceptance_test.go
+++ b/server/experiments/agenttransport/acceptance_test.go
@@ -1,0 +1,207 @@
+package agenttransport
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type controlledRunner struct {
+	executions atomic.Int32
+	started    chan struct{}
+	release    chan struct{}
+	once       sync.Once
+}
+
+func (r *controlledRunner) Run(ctx context.Context, prompt string, emit func(string)) error {
+	r.executions.Add(1)
+	r.once.Do(func() { close(r.started) })
+	emit("before disconnect")
+	select {
+	case <-r.release:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	emit("after disconnect")
+	return nil
+}
+
+func setup(t *testing.T) (*controlledRunner, *httptest.Server) {
+	t.Helper()
+	runner := &controlledRunner{started: make(chan struct{}), release: make(chan struct{})}
+	runtime := NewReference(runner)
+	server := httptest.NewServer(runtime)
+	t.Cleanup(func() { runtime.Close(); server.Close() })
+	return runner, server
+}
+
+func submit(t *testing.T, server *httptest.Server, command Command, status int) {
+	t.Helper()
+	body, _ := json.Marshal(command)
+	client := &http.Client{Timeout: 5 * time.Second}
+	response, err := client.Post(server.URL+"/commands", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != status {
+		t.Fatalf("submit: got %d, want %d", response.StatusCode, status)
+	}
+}
+
+func subscribe(t *testing.T, server *httptest.Server, cursor int) (*http.Response, *bufio.Scanner) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/events", nil)
+	req.Header.Set("Last-Event-ID", fmt.Sprint(cursor))
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { response.Body.Close() })
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("subscribe: %d", response.StatusCode)
+	}
+	return response, bufio.NewScanner(response.Body)
+}
+
+func next(t *testing.T, scanner *bufio.Scanner) Event {
+	t.Helper()
+	for scanner.Scan() {
+		if data, ok := strings.CutPrefix(scanner.Text(), "data: "); ok {
+			var event Event
+			if err := json.Unmarshal([]byte(data), &event); err != nil {
+				t.Fatal(err)
+			}
+			return event
+		}
+	}
+	t.Fatalf("stream ended before expected event: %v", scanner.Err())
+	return Event{}
+}
+
+func waitStarted(t *testing.T, runner *controlledRunner) {
+	t.Helper()
+	select {
+	case <-runner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not start")
+	}
+}
+
+func TestDisconnectRetryAndReplay(t *testing.T) {
+	runner, server := setup(t)
+	response, scanner := subscribe(t, server, 0)
+	command := Command{"op-1", "perform a counted operation"}
+	submit(t, server, command, http.StatusAccepted)
+	first := next(t, scanner)
+	second := next(t, scanner)
+	if first.Sequence != 1 || first.Kind != "accepted" || second.Sequence != 2 || second.Text != "before disconnect" {
+		t.Fatalf("unexpected initial events: %+v %+v", first, second)
+	}
+	// Close the real HTTP stream while the runner remains blocked mid-turn.
+	response.Body.Close()
+	close(runner.release)
+	submit(t, server, command, http.StatusAccepted)
+	_, reconnected := subscribe(t, server, second.Sequence)
+	output, done := next(t, reconnected), next(t, reconnected)
+	if output.Sequence != 3 || output.Text != "after disconnect" || done.Sequence != 4 || done.Kind != "completed" {
+		t.Fatalf("unexpected replay: %+v %+v", output, done)
+	}
+	if runner.executions.Load() != 1 {
+		t.Fatalf("executions: %d", runner.executions.Load())
+	}
+	// A retry after completion must also be harmless; full replay has one acceptance.
+	submit(t, server, command, http.StatusAccepted)
+	_, full := subscribe(t, server, 0)
+	for sequence := 1; sequence <= 4; sequence++ {
+		if event := next(t, full); event.Sequence != sequence {
+			t.Fatalf("sequence: %+v", event)
+		}
+	}
+	if runner.executions.Load() != 1 {
+		t.Fatal("completed operation executed again")
+	}
+}
+
+func TestLostSubmitResponseDoesNotRepeatExecution(t *testing.T) {
+	runner, server := setup(t)
+	conn, err := net.DialTimeout("tcp", strings.TrimPrefix(server.URL, "http://"), 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	command := Command{"lost-ack", "perform a counted operation"}
+	body, _ := json.Marshal(command)
+	// Submit over TCP and deliberately never read the acknowledgement.
+	if _, err := fmt.Fprintf(conn, "POST /commands HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", len(body), body); err != nil {
+		t.Fatal(err)
+	}
+	waitStarted(t, runner)
+	conn.Close()
+	submit(t, server, command, http.StatusAccepted)
+	close(runner.release)
+	_, scanner := subscribe(t, server, 0)
+	for sequence := 1; sequence <= 4; sequence++ {
+		event := next(t, scanner)
+		if event.Sequence != sequence || event.OperationID != command.ID {
+			t.Fatalf("unexpected event: %+v", event)
+		}
+		if sequence == 4 && event.Kind != "completed" {
+			t.Fatalf("not completed: %+v", event)
+		}
+	}
+	if runner.executions.Load() != 1 {
+		t.Fatalf("executions: %d", runner.executions.Load())
+	}
+}
+
+func TestConcurrentRetriesAndPayloadConflict(t *testing.T) {
+	runner, server := setup(t)
+	command := Command{"same-id", "original"}
+	var group sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		group.Add(1)
+		go func() { defer group.Done(); submit(t, server, command, http.StatusAccepted) }()
+	}
+	group.Wait()
+	waitStarted(t, runner)
+	submit(t, server, Command{"same-id", "different"}, http.StatusConflict)
+	if runner.executions.Load() != 1 {
+		t.Fatalf("executions: %d", runner.executions.Load())
+	}
+	close(runner.release)
+}
+
+func TestInvalidReplayCursor(t *testing.T) {
+	_, server := setup(t)
+	for _, test := range []struct {
+		cursor string
+		status int
+	}{{"-1", 400}, {"invalid", 400}, {"1", 409}} {
+		t.Run(test.cursor, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, server.URL+"/events", nil)
+			req.Header.Set("Last-Event-ID", test.cursor)
+			response, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			if response.StatusCode != test.status {
+				t.Fatalf("got %d, want %d", response.StatusCode, test.status)
+			}
+		})
+	}
+}

--- a/server/experiments/agenttransport/acceptance_test.go
+++ b/server/experiments/agenttransport/acceptance_test.go
@@ -24,17 +24,18 @@ type controlledRunner struct {
 	once       sync.Once
 }
 
-func (r *controlledRunner) Run(ctx context.Context, prompt string, emit func(string)) error {
+func (r *controlledRunner) Run(ctx context.Context, prompt string, turn *Turn) error {
 	r.executions.Add(1)
 	r.once.Do(func() { close(r.started) })
-	emit("before disconnect")
+	if err := turn.Output("before disconnect"); err != nil {
+		return err
+	}
 	select {
 	case <-r.release:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-	emit("after disconnect")
-	return nil
+	return turn.Output("after disconnect")
 }
 
 func setup(t *testing.T) (*controlledRunner, *httptest.Server) {

--- a/server/experiments/agenttransport/acceptance_test.go
+++ b/server/experiments/agenttransport/acceptance_test.go
@@ -24,7 +24,7 @@ type controlledRunner struct {
 	once       sync.Once
 }
 
-func (r *controlledRunner) Run(ctx context.Context, prompt string, turn *Turn) error {
+func (r *controlledRunner) Run(ctx context.Context, prompt json.RawMessage, turn *Turn) error {
 	r.executions.Add(1)
 	r.once.Do(func() { close(r.started) })
 	if err := turn.Output("before disconnect"); err != nil {
@@ -81,7 +81,9 @@ func subscribe(t *testing.T, server *httptest.Server, cursor int) (*http.Respons
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("subscribe: %d", response.StatusCode)
 	}
-	return response, bufio.NewScanner(response.Body)
+	scanner := bufio.NewScanner(response.Body)
+	scanner.Buffer(make([]byte, 4096), 16<<20)
+	return response, scanner
 }
 
 func next(t *testing.T, scanner *bufio.Scanner) Event {
@@ -122,7 +124,7 @@ func waitStarted(t *testing.T, runner *controlledRunner) {
 func TestDisconnectRetryAndReplay(t *testing.T) {
 	runner, server := setup(t)
 	response, scanner := subscribe(t, server, 0)
-	command := Command{"op-1", "perform a counted operation"}
+	command := Command{"op-1", TextPrompt("perform a counted operation")}
 	submit(t, server, command, http.StatusAccepted)
 	first := next(t, scanner)
 	second := next(t, scanner)
@@ -162,7 +164,7 @@ func TestLostSubmitResponseDoesNotRepeatExecution(t *testing.T) {
 	}
 	defer conn.Close()
 	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
-	command := Command{"lost-ack", "perform a counted operation"}
+	command := Command{"lost-ack", TextPrompt("perform a counted operation")}
 	body, _ := json.Marshal(command)
 	// Submit over TCP and deliberately never read the acknowledgement.
 	if _, err := fmt.Fprintf(conn, "POST /commands HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", len(body), body); err != nil {
@@ -189,7 +191,7 @@ func TestLostSubmitResponseDoesNotRepeatExecution(t *testing.T) {
 
 func TestConcurrentRetriesAndPayloadConflict(t *testing.T) {
 	runner, server := setup(t)
-	command := Command{"same-id", "original"}
+	command := Command{"same-id", TextPrompt("original")}
 	var group sync.WaitGroup
 	for i := 0; i < 20; i++ {
 		group.Add(1)
@@ -197,7 +199,7 @@ func TestConcurrentRetriesAndPayloadConflict(t *testing.T) {
 	}
 	group.Wait()
 	waitStarted(t, runner)
-	submit(t, server, Command{"same-id", "different"}, http.StatusConflict)
+	submit(t, server, Command{"same-id", TextPrompt("different")}, http.StatusConflict)
 	if runner.executions.Load() != 1 {
 		t.Fatalf("executions: %d", runner.executions.Load())
 	}

--- a/server/experiments/agenttransport/acp/client.go
+++ b/server/experiments/agenttransport/acp/client.go
@@ -53,20 +53,22 @@ type received struct {
 	err error
 }
 type Client struct {
-	command      *exec.Cmd
-	stdin        *os.File
-	stdout       *os.File
-	incoming     chan received
-	stopped      chan struct{}
-	exited       chan struct{}
-	once         sync.Once
-	sendMu       sync.Mutex
-	callMu       sync.Mutex
-	next         int
-	sessionID    string
-	Capabilities json.RawMessage
-	dispatches   atomic.Int32
-	forcedStops  atomic.Int32
+	command       *exec.Cmd
+	stdin         *os.File
+	stdout        *os.File
+	incoming      chan received
+	stopped       chan struct{}
+	exited        chan struct{}
+	processCtx    context.Context
+	processFailed context.CancelCauseFunc
+	once          sync.Once
+	sendMu        sync.Mutex
+	callMu        sync.Mutex
+	next          int
+	sessionID     string
+	Capabilities  json.RawMessage
+	dispatches    atomic.Int32
+	forcedStops   atomic.Int32
 }
 
 func Start(ctx context.Context, config Config, stderr io.Writer) (*Client, error) {
@@ -114,8 +116,13 @@ func Start(ctx context.Context, config Config, stderr io.Writer) (*Client, error
 	}
 	inputRead.Close()
 	outputWrite.Close()
-	c := &Client{command: command, stdin: inputWrite, stdout: outputRead, incoming: make(chan received, 64), stopped: make(chan struct{}), exited: make(chan struct{})}
-	go func() { _ = command.Wait(); close(c.exited) }()
+	processCtx, processFailed := context.WithCancelCause(context.Background())
+	c := &Client{command: command, stdin: inputWrite, stdout: outputRead, incoming: make(chan received, 64), stopped: make(chan struct{}), exited: make(chan struct{}), processCtx: processCtx, processFailed: processFailed}
+	go func() {
+		_ = command.Wait()
+		c.processFailed(fmt.Errorf("%w: agent process exited", transport.ErrUncertain))
+		close(c.exited)
+	}()
 	go c.read()
 	fail := func(err error) (*Client, error) { c.Close(); return nil, err }
 	result, err := c.call(ctx, "initialize", map[string]any{"protocolVersion": 1, "clientCapabilities": map[string]any{}, "clientInfo": map[string]string{"name": "transport-acceptance", "version": "1"}}, nil)
@@ -172,10 +179,12 @@ func Start(ctx context.Context, config Config, stderr io.Writer) (*Client, error
 func (c *Client) PID() int         { return c.command.Process.Pid }
 func (c *Client) Dispatches() int  { return int(c.dispatches.Load()) }
 func (c *Client) ForcedStops() int { return int(c.forcedStops.Load()) }
+func (c *Client) Kill()            { _ = syscall.Kill(-c.PID(), syscall.SIGKILL) }
 func (c *Client) Close() {
 	c.once.Do(func() {
+		c.processFailed(fmt.Errorf("%w: ACP client closed", transport.ErrUncertain))
 		close(c.stopped)
-		_ = syscall.Kill(-c.PID(), syscall.SIGKILL)
+		c.Kill()
 		c.stdin.Close()
 		c.stdout.Close()
 		<-c.exited
@@ -194,6 +203,7 @@ func split(data []byte, atEOF bool) (int, []byte, error) {
 	return 0, nil, nil
 }
 func (c *Client) read() {
+	defer c.processFailed(fmt.Errorf("%w: ACP stream ended", transport.ErrUncertain))
 	scanner := bufio.NewScanner(c.stdout)
 	scanner.Split(split)
 	scanner.Buffer(make([]byte, 4096), 8<<20)
@@ -310,7 +320,11 @@ func (c *Client) receive(ctx context.Context, id json.RawMessage, turn *transpor
 			}
 			outcome := map[string]string{"outcome": "cancelled"}
 			if turn != nil {
-				option, err := turn.Permission(string(msg.ID), msg.Params)
+				permissionCtx, cancel := context.WithCancelCause(ctx)
+				stop := context.AfterFunc(c.processCtx, func() { cancel(context.Cause(c.processCtx)) })
+				option, err := turn.Permission(permissionCtx, string(msg.ID), msg.Params)
+				stop()
+				cancel(nil)
 				if err == nil {
 					outcome = map[string]string{"outcome": "selected", "optionId": option}
 				} else if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {

--- a/server/experiments/agenttransport/acp/client.go
+++ b/server/experiments/agenttransport/acp/client.go
@@ -281,6 +281,11 @@ func (c *Client) receive(ctx context.Context, id json.RawMessage, turn *transpor
 				if !bytes.Equal(msg.ID, id) {
 					return nil, errors.New("unexpected ACP response ID")
 				}
+				if turn != nil {
+					if err := turn.Emit("acp", event.raw); err != nil {
+						return nil, err
+					}
+				}
 				if len(msg.Error) > 0 {
 					return nil, &RPCError{Detail: string(msg.Error)}
 				}
@@ -337,14 +342,17 @@ func (c *Client) receive(ctx context.Context, id json.RawMessage, turn *transpor
 		}
 	}
 }
-func (c *Client) Run(ctx context.Context, prompt string, turn *transport.Turn) error {
+func (c *Client) Run(ctx context.Context, prompt json.RawMessage, turn *transport.Turn) error {
 	c.callMu.Lock()
 	defer c.callMu.Unlock()
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if err := c.ValidatePrompt(prompt); err != nil {
+		return err
+	}
 	c.dispatches.Add(1)
-	id, err := c.request("session/prompt", map[string]any{"sessionId": c.sessionID, "prompt": []map[string]string{{"type": "text", "text": prompt}}})
+	id, err := c.request("session/prompt", map[string]any{"sessionId": c.sessionID, "prompt": prompt})
 	if err != nil {
 		c.Close()
 		return fmt.Errorf("%w: %v", transport.ErrUncertain, err)

--- a/server/experiments/agenttransport/acp/client.go
+++ b/server/experiments/agenttransport/acp/client.go
@@ -66,6 +66,7 @@ type Client struct {
 	sessionID    string
 	Capabilities json.RawMessage
 	dispatches   atomic.Int32
+	forcedStops  atomic.Int32
 }
 
 func Start(ctx context.Context, config Config, stderr io.Writer) (*Client, error) {
@@ -168,8 +169,9 @@ func Start(ctx context.Context, config Config, stderr io.Writer) (*Client, error
 	}
 	return c, nil
 }
-func (c *Client) PID() int        { return c.command.Process.Pid }
-func (c *Client) Dispatches() int { return int(c.dispatches.Load()) }
+func (c *Client) PID() int         { return c.command.Process.Pid }
+func (c *Client) Dispatches() int  { return int(c.dispatches.Load()) }
+func (c *Client) ForcedStops() int { return int(c.forcedStops.Load()) }
 func (c *Client) Close() {
 	c.once.Do(func() {
 		close(c.stopped)
@@ -341,6 +343,7 @@ func (c *Client) Run(ctx context.Context, prompt string, turn *transport.Turn) e
 		defer cancel()
 		if result == nil {
 			if _, err := c.receive(drain, id, turn); err != nil {
+				c.forcedStops.Add(1)
 				c.Close()
 			}
 		}

--- a/server/experiments/agenttransport/acp/client.go
+++ b/server/experiments/agenttransport/acp/client.go
@@ -1,0 +1,367 @@
+// Package acp provides a deliberately small ACP v1 stdio test driver. It keeps
+// the agent process alive across HTTP detach/attach; it is not a general SDK.
+package acp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	transport "github.com/kernel/kernel-images/server/experiments/agenttransport"
+)
+
+type Config struct {
+	Command    string            `json:"command"`
+	Args       []string          `json:"args"`
+	Cwd        string            `json:"cwd"`
+	Env        []string          `json:"env"`
+	InheritEnv []string          `json:"inheritEnv,omitempty"`
+	MCPServers []json.RawMessage `json:"mcpServers"`
+	AuthMethod string            `json:"authMethod,omitempty"`
+	Setup      []SetupCall       `json:"setup,omitempty"`
+}
+type SetupCall struct {
+	Method string         `json:"method"`
+	Params map[string]any `json:"params"`
+}
+type message struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty"`
+}
+type RPCError struct{ Detail string }
+
+func (e *RPCError) Error() string { return "ACP request failed: " + e.Detail }
+
+type received struct {
+	raw json.RawMessage
+	msg message
+	err error
+}
+type Client struct {
+	command      *exec.Cmd
+	stdin        *os.File
+	stdout       *os.File
+	incoming     chan received
+	stopped      chan struct{}
+	exited       chan struct{}
+	once         sync.Once
+	sendMu       sync.Mutex
+	callMu       sync.Mutex
+	next         int
+	sessionID    string
+	Capabilities json.RawMessage
+	dispatches   atomic.Int32
+}
+
+func Start(ctx context.Context, config Config, stderr io.Writer) (*Client, error) {
+	if !filepath.IsAbs(config.Cwd) {
+		return nil, errors.New("absolute workspace required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	command := exec.Command(config.Command, config.Args...)
+	command.Dir = config.Cwd
+	for _, name := range []string{"PATH", "HOME", "USER", "LANG", "TMPDIR", "TERM", "SSL_CERT_FILE", "SSL_CERT_DIR"} {
+		if value, ok := os.LookupEnv(name); ok {
+			command.Env = append(command.Env, name+"="+value)
+		}
+	}
+	for _, name := range config.InheritEnv {
+		value, ok := os.LookupEnv(name)
+		if !ok {
+			return nil, fmt.Errorf("missing inherited environment variable %s", name)
+		}
+		command.Env = append(command.Env, name+"="+value)
+	}
+	command.Env = append(command.Env, config.Env...)
+	command.Stderr = stderr
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	inputRead, inputWrite, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	outputRead, outputWrite, err := os.Pipe()
+	if err != nil {
+		inputRead.Close()
+		inputWrite.Close()
+		return nil, err
+	}
+	command.Stdin = inputRead
+	command.Stdout = outputWrite
+	if err := command.Start(); err != nil {
+		inputRead.Close()
+		inputWrite.Close()
+		outputRead.Close()
+		outputWrite.Close()
+		return nil, err
+	}
+	inputRead.Close()
+	outputWrite.Close()
+	c := &Client{command: command, stdin: inputWrite, stdout: outputRead, incoming: make(chan received, 64), stopped: make(chan struct{}), exited: make(chan struct{})}
+	go func() { _ = command.Wait(); close(c.exited) }()
+	go c.read()
+	fail := func(err error) (*Client, error) { c.Close(); return nil, err }
+	result, err := c.call(ctx, "initialize", map[string]any{"protocolVersion": 1, "clientCapabilities": map[string]any{}, "clientInfo": map[string]string{"name": "transport-acceptance", "version": "1"}}, nil)
+	if err != nil {
+		return fail(err)
+	}
+	var initialized struct {
+		ProtocolVersion int `json:"protocolVersion"`
+	}
+	if err := json.Unmarshal(result, &initialized); err != nil {
+		return fail(err)
+	}
+	if initialized.ProtocolVersion != 1 {
+		return fail(errors.New("test driver requires ACP v1"))
+	}
+	c.Capabilities = append(json.RawMessage(nil), result...)
+	if config.AuthMethod != "" {
+		if _, err := c.call(ctx, "authenticate", map[string]string{"methodId": config.AuthMethod}, nil); err != nil {
+			return fail(err)
+		}
+	}
+	servers := config.MCPServers
+	if servers == nil {
+		servers = make([]json.RawMessage, 0)
+	}
+	result, err = c.call(ctx, "session/new", map[string]any{"cwd": config.Cwd, "mcpServers": servers}, nil)
+	if err != nil {
+		return fail(err)
+	}
+	var session struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(result, &session); err != nil || session.SessionID == "" {
+		return fail(errors.New("session/new did not return a session ID"))
+	}
+	c.sessionID = session.SessionID
+	for _, setup := range config.Setup {
+		switch setup.Method {
+		case "session/set_config_option", "session/set_mode", "session/set_model":
+		default:
+			return fail(fmt.Errorf("unsupported setup method %q", setup.Method))
+		}
+		params := make(map[string]any)
+		for key, value := range setup.Params {
+			params[key] = value
+		}
+		params["sessionId"] = c.sessionID
+		if _, err := c.call(ctx, setup.Method, params, nil); err != nil {
+			return fail(err)
+		}
+	}
+	return c, nil
+}
+func (c *Client) PID() int        { return c.command.Process.Pid }
+func (c *Client) Dispatches() int { return int(c.dispatches.Load()) }
+func (c *Client) Close() {
+	c.once.Do(func() {
+		close(c.stopped)
+		_ = syscall.Kill(-c.PID(), syscall.SIGKILL)
+		c.stdin.Close()
+		c.stdout.Close()
+		<-c.exited
+	})
+}
+
+// Split only on LF. JSON strings can contain Unicode separators that must not
+// be interpreted as framing, and partial final records are protocol errors.
+func split(data []byte, atEOF bool) (int, []byte, error) {
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		return i + 1, data[:i], nil
+	}
+	if atEOF && len(data) > 0 {
+		return 0, nil, io.ErrUnexpectedEOF
+	}
+	return 0, nil, nil
+}
+func (c *Client) read() {
+	scanner := bufio.NewScanner(c.stdout)
+	scanner.Split(split)
+	scanner.Buffer(make([]byte, 4096), 8<<20)
+	for scanner.Scan() {
+		raw := append(json.RawMessage(nil), scanner.Bytes()...)
+		var msg message
+		err := json.Unmarshal(raw, &msg)
+		if err == nil && msg.JSONRPC != "2.0" {
+			err = errors.New("invalid JSON-RPC version")
+		}
+		select {
+		case c.incoming <- received{raw, msg, err}:
+		case <-c.stopped:
+			return
+		}
+		if err != nil {
+			return
+		}
+	}
+	err := scanner.Err()
+	if err == nil {
+		err = io.EOF
+	}
+	select {
+	case c.incoming <- received{err: err}:
+	case <-c.stopped:
+	}
+}
+func (c *Client) send(value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	if err := c.stdin.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return err
+	}
+	n, err := c.stdin.Write(data)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
+	}
+	return err
+}
+func (c *Client) request(method string, params any) (json.RawMessage, error) {
+	c.next++
+	id := json.RawMessage(fmt.Sprint(c.next))
+	err := c.send(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params})
+	return id, err
+}
+func (c *Client) call(ctx context.Context, method string, params any, turn *transport.Turn) (json.RawMessage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	id, err := c.request(method, params)
+	if err != nil {
+		return nil, err
+	}
+	return c.receive(ctx, id, turn)
+}
+func (c *Client) receive(ctx context.Context, id json.RawMessage, turn *transport.Turn) (json.RawMessage, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-c.stopped:
+			return nil, errors.New("ACP process closed")
+		case event := <-c.incoming:
+			if event.err != nil {
+				return nil, event.err
+			}
+			msg := event.msg
+			if msg.Method == "" {
+				if !bytes.Equal(msg.ID, id) {
+					return nil, errors.New("unexpected ACP response ID")
+				}
+				if len(msg.Error) > 0 {
+					return nil, &RPCError{Detail: string(msg.Error)}
+				}
+				return msg.Result, nil
+			}
+			if msg.Method == "session/update" {
+				var params struct {
+					SessionID string `json:"sessionId"`
+				}
+				if err := json.Unmarshal(msg.Params, &params); err != nil {
+					return nil, err
+				}
+				if c.sessionID != "" && params.SessionID != c.sessionID {
+					return nil, errors.New("update for another ACP session")
+				}
+				if turn != nil {
+					if err := turn.Emit("acp", event.raw); err != nil && ctx.Err() == nil {
+						return nil, err
+					}
+				}
+				continue
+			}
+			if len(msg.ID) == 0 {
+				continue
+			}
+			if msg.Method != "session/request_permission" {
+				if err := c.send(map[string]any{"jsonrpc": "2.0", "id": msg.ID, "error": map[string]any{"code": -32601, "message": "test client does not implement this capability"}}); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			var params struct {
+				SessionID string `json:"sessionId"`
+			}
+			if err := json.Unmarshal(msg.Params, &params); err != nil || params.SessionID != c.sessionID {
+				return nil, errors.New("permission for another ACP session")
+			}
+			outcome := map[string]string{"outcome": "cancelled"}
+			if turn != nil {
+				option, err := turn.Permission(string(msg.ID), msg.Params)
+				if err == nil {
+					outcome = map[string]string{"outcome": "selected", "optionId": option}
+				} else if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+					return nil, err
+				}
+			}
+			if err := c.send(map[string]any{"jsonrpc": "2.0", "id": msg.ID, "result": map[string]any{"outcome": outcome}}); err != nil {
+				return nil, err
+			}
+		}
+	}
+}
+func (c *Client) Run(ctx context.Context, prompt string, turn *transport.Turn) error {
+	c.callMu.Lock()
+	defer c.callMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.dispatches.Add(1)
+	id, err := c.request("session/prompt", map[string]any{"sessionId": c.sessionID, "prompt": []map[string]string{{"type": "text", "text": prompt}}})
+	if err != nil {
+		c.Close()
+		return fmt.Errorf("%w: %v", transport.ErrUncertain, err)
+	}
+	result, err := c.receive(ctx, id, turn)
+	if ctx.Err() != nil {
+		_ = c.send(map[string]any{"jsonrpc": "2.0", "method": "session/cancel", "params": map[string]string{"sessionId": c.sessionID}})
+		// Do not allow another prompt until the agent has stopped or been killed.
+		drain, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if result == nil {
+			if _, err := c.receive(drain, id, turn); err != nil {
+				c.Close()
+			}
+		}
+		return ctx.Err()
+	}
+	if err != nil {
+		var rpcError *RPCError
+		if errors.As(err, &rpcError) {
+			return err
+		}
+		c.Close()
+		return fmt.Errorf("%w: %v", transport.ErrUncertain, err)
+	}
+	var completion struct {
+		StopReason string `json:"stopReason"`
+	}
+	if err := json.Unmarshal(result, &completion); err != nil {
+		return err
+	}
+	if completion.StopReason != "end_turn" {
+		return fmt.Errorf("agent stopped with %q", completion.StopReason)
+	}
+	return nil
+}

--- a/server/experiments/agenttransport/acp/content.go
+++ b/server/experiments/agenttransport/acp/content.go
@@ -1,0 +1,48 @@
+package acp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	transport "github.com/kernel/kernel-images/server/experiments/agenttransport"
+)
+
+// Capability checks do not rewrite the content or discard optional fields.
+func (c *Client) ValidatePrompt(prompt json.RawMessage) error {
+	var initialized struct {
+		AgentCapabilities struct {
+			PromptCapabilities struct {
+				Image           bool `json:"image"`
+				Audio           bool `json:"audio"`
+				EmbeddedContext bool `json:"embeddedContext"`
+			} `json:"promptCapabilities"`
+		} `json:"agentCapabilities"`
+	}
+	if err := json.Unmarshal(c.Capabilities, &initialized); err != nil {
+		return err
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(prompt, &blocks); err != nil || len(blocks) == 0 {
+		return fmt.Errorf("%w: expected ACP content blocks", transport.ErrInvalidCommand)
+	}
+	caps := initialized.AgentCapabilities.PromptCapabilities
+	for _, block := range blocks {
+		supported := false
+		switch block.Type {
+		case "text", "resource_link":
+			supported = true
+		case "image":
+			supported = caps.Image
+		case "audio":
+			supported = caps.Audio
+		case "resource":
+			supported = caps.EmbeddedContext
+		}
+		if !supported {
+			return fmt.Errorf("%w: agent does not support prompt content type %q", transport.ErrInvalidCommand, block.Type)
+		}
+	}
+	return nil
+}

--- a/server/experiments/agenttransport/acp/content_test.go
+++ b/server/experiments/agenttransport/acp/content_test.go
@@ -1,0 +1,239 @@
+package acp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	transport "github.com/kernel/kernel-images/server/experiments/agenttransport"
+)
+
+func TestContentPeer(t *testing.T) {
+	path := os.Getenv("ACP_CONTENT_PEER")
+	if path == "" {
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 4096), 8<<20)
+	encoder := json.NewEncoder(os.Stdout)
+	send := func(value any) {
+		if err := encoder.Encode(value); err != nil {
+			os.Exit(1)
+		}
+	}
+	for scanner.Scan() {
+		var msg message
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			os.Exit(1)
+		}
+		var result any
+		switch msg.Method {
+		case "initialize":
+			result = json.RawMessage(fmt.Sprintf(`{"protocolVersion":1,"agentCapabilities":{"promptCapabilities":%s}}`, os.Getenv("ACP_CONTENT_CAPS")))
+		case "session/new":
+			result = map[string]string{"sessionId": "native-session"}
+		case "session/prompt":
+			var params struct {
+				SessionID string            `json:"sessionId"`
+				Prompt    []json.RawMessage `json:"prompt"`
+			}
+			if json.Unmarshal(msg.Params, &params) != nil || params.SessionID != "native-session" {
+				os.Exit(1)
+			}
+			if err := os.WriteFile(path, msg.Params, 0600); err != nil {
+				os.Exit(1)
+			}
+			for _, block := range params.Prompt {
+				send(map[string]any{"jsonrpc": "2.0", "method": "session/update", "params": map[string]any{"sessionId": params.SessionID, "update": map[string]any{"sessionUpdate": "agent_message_chunk", "content": block}, "_meta": map[string]string{"fixture": "preserved"}}})
+			}
+			result = json.RawMessage(`{"stopReason":"end_turn","_meta":{"fixtureUsage":9007199254740993}}`)
+		default:
+			os.Exit(1)
+		}
+		send(map[string]any{"jsonrpc": "2.0", "id": msg.ID, "result": result})
+	}
+	os.Exit(0)
+}
+
+func contentClient(t *testing.T, caps string) (*Client, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "received.json")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client, err := Start(ctx, Config{Command: os.Args[0], Args: []string{"-test.run=^TestContentPeer$"}, Cwd: filepath.Dir(path), Env: []string{"ACP_CONTENT_PEER=" + path, "ACP_CONTENT_CAPS=" + caps}}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(client.Close)
+	return client, path
+}
+
+func equalJSON(t *testing.T, got, want json.RawMessage) {
+	t.Helper()
+	decode := func(data []byte) any {
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.UseNumber()
+		var value any
+		if err := decoder.Decode(&value); err != nil {
+			t.Fatal(err)
+		}
+		return value
+	}
+	if !reflect.DeepEqual(decode(got), decode(want)) {
+		t.Fatal("ACP JSON changed in transit")
+	}
+}
+
+func TestContentThroughHTTPACPAndJournal(t *testing.T) {
+	client, receivedPath := contentClient(t, `{"image":true,"audio":true,"embeddedContext":true}`)
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	store, err := transport.OpenFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := transport.NewRuntime(client, store)
+	if err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(runtime)
+	t.Cleanup(func() { runtime.Close(); server.Close() })
+	prompt := json.RawMessage(fmt.Sprintf(`[
+		{"type":"text","text":"inspect these inputs","annotations":{"audience":["assistant"]},"_meta":{"n":9007199254740993}},
+		{"type":"image","data":"AAEC","mimeType":"image/png","uri":"file:///image.png"},
+		{"type":"audio","data":"AAEC","mimeType":"audio/wav"},
+		{"type":"resource","resource":{"uri":"file:///large.txt","text":"%s","mimeType":"text/plain"}},
+		{"type":"resource","resource":{"uri":"file:///data.bin","blob":"AAEC","mimeType":"application/octet-stream"}},
+		{"type":"resource_link","uri":"file:///source.go","name":"source.go","description":"source","size":123,"_meta":{"custom":true}}
+	]`, strings.Repeat("x", 70<<10)))
+	command := transport.Command{ID: "mixed-content", Prompt: prompt}
+	body, err := json.Marshal(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	response, err := httpClient.Post(server.URL+"/commands", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != 202 {
+		t.Fatalf("submit: %d", response.StatusCode)
+	}
+	response, err = httpClient.Get(server.URL + "/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	scanner := bufio.NewScanner(response.Body)
+	scanner.Buffer(make([]byte, 4096), 16<<20)
+	var replay []transport.Event
+	for scanner.Scan() {
+		data, ok := strings.CutPrefix(scanner.Text(), "data: ")
+		if !ok {
+			continue
+		}
+		var event transport.Event
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			t.Fatal(err)
+		}
+		replay = append(replay, event)
+		if event.Kind == "completed" || event.Kind == "failed" || event.Kind == "uncertain" {
+			break
+		}
+	}
+	response.Body.Close()
+	if len(replay) != 9 || replay[len(replay)-1].Kind != "completed" {
+		t.Fatalf("incomplete content replay: %d events, scanner=%v", len(replay), scanner.Err())
+	}
+	equalJSON(t, replay[0].Command.Prompt, prompt)
+	data, err := os.ReadFile(receivedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var received struct {
+		Prompt json.RawMessage `json:"prompt"`
+	}
+	if err := json.Unmarshal(data, &received); err != nil {
+		t.Fatal(err)
+	}
+	equalJSON(t, received.Prompt, prompt)
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(prompt, &blocks); err != nil {
+		t.Fatal(err)
+	}
+	for i, block := range blocks {
+		var update struct {
+			Params struct {
+				Update struct {
+					Content json.RawMessage `json:"content"`
+				} `json:"update"`
+				Meta map[string]string `json:"_meta"`
+			} `json:"params"`
+		}
+		if err := json.Unmarshal(replay[i+1].Payload, &update); err != nil {
+			t.Fatal(err)
+		}
+		equalJSON(t, update.Params.Update.Content, block)
+		if update.Params.Meta["fixture"] != "preserved" {
+			t.Fatal("update metadata dropped")
+		}
+	}
+	var completion message
+	if err := json.Unmarshal(replay[7].Payload, &completion); err != nil {
+		t.Fatal(err)
+	}
+	equalJSON(t, completion.Result, json.RawMessage(`{"stopReason":"end_turn","_meta":{"fixtureUsage":9007199254740993}}`))
+	runtime.Close()
+	client.Close()
+	store, err = transport.OpenFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := transport.NewRuntime(client, store)
+	if err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	defer restored.Close()
+	op, err := restored.Submit(command)
+	if err != nil || op.State != "completed" || client.Dispatches() != 1 {
+		t.Fatalf("completed content retry redispatched: %+v %v", op, err)
+	}
+	equalJSON(t, op.Command.Prompt, prompt)
+	events, err := store.Load()
+	if err != nil || !reflect.DeepEqual(events, replay) {
+		t.Fatalf("journal recovery changed content: %v", err)
+	}
+}
+
+func TestUnsupportedContentDoesNotDispatch(t *testing.T) {
+	client, _ := contentClient(t, `{}`)
+	runtime := transport.NewReference(client)
+	defer runtime.Close()
+	for _, kind := range []string{"image", "audio", "resource", "unknown"} {
+		_, err := runtime.Submit(transport.Command{ID: kind, Prompt: json.RawMessage(fmt.Sprintf(`[{"type":%q}]`, kind))})
+		if err == nil {
+			t.Fatalf("unsupported %s accepted", kind)
+		}
+	}
+	for _, prompt := range []string{`[{"type":"text","text":"ok"}]`, `[{"type":"resource_link","name":"source","uri":"file:///source"}]`} {
+		if err := client.ValidatePrompt(json.RawMessage(prompt)); err != nil {
+			t.Fatalf("baseline content rejected: %v", err)
+		}
+	}
+	if client.Dispatches() != 0 {
+		t.Fatal("unsupported content dispatched")
+	}
+}

--- a/server/experiments/agenttransport/cmd/agent-probe/main.go
+++ b/server/experiments/agenttransport/cmd/agent-probe/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/kernel/kernel-images/server/experiments/agenttransport/probe"
+)
+
+func main() {
+	mode := flag.String("mode", "mcp", "mcp or deterministic-acp")
+	dir := flag.String("dir", "", "existing checkpoint directory")
+	flag.Parse()
+	if *dir == "" {
+		fmt.Fprintln(os.Stderr, "--dir required")
+		os.Exit(2)
+	}
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+	var err error
+	switch *mode {
+	case "mcp":
+		err = probe.ServeMCP(ctx, os.Stdin, os.Stdout, probe.Probe{Dir: *dir})
+	case "deterministic-acp":
+		err = probe.ServeACP(ctx, os.Stdin, os.Stdout, probe.Probe{Dir: *dir})
+	default:
+		fmt.Fprintln(os.Stderr, "unknown mode")
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/server/experiments/agenttransport/content.go
+++ b/server/experiments/agenttransport/content.go
@@ -1,0 +1,56 @@
+package agenttransport
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MaxPromptBytes bounds the encoded content array, including base64 media.
+const MaxPromptBytes = 4 << 20
+
+var ErrInvalidCommand = errors.New("invalid command")
+
+// TextPrompt is a convenience for callers that only need one ACP text block.
+func TextPrompt(text string) json.RawMessage {
+	data, _ := json.Marshal([]map[string]string{{"type": "text", "text": text}})
+	return data
+}
+
+// Keep content as JSON rather than a reduced union that drops ACP metadata.
+// Canonical member ordering makes retries insensitive to JSON formatting.
+func normalizePrompt(prompt json.RawMessage) (json.RawMessage, error) {
+	if len(prompt) > MaxPromptBytes {
+		return nil, fmt.Errorf("%w: prompt exceeds size limit", ErrInvalidCommand)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(prompt))
+	decoder.UseNumber()
+	var blocks []map[string]any
+	if err := decoder.Decode(&blocks); err != nil || len(blocks) == 0 {
+		return nil, fmt.Errorf("%w: prompt must be a nonempty ACP content array", ErrInvalidCommand)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, fmt.Errorf("%w: expected one content array", ErrInvalidCommand)
+	}
+	for _, block := range blocks {
+		if kind, ok := block["type"].(string); !ok || kind == "" {
+			return nil, fmt.Errorf("%w: content block requires type", ErrInvalidCommand)
+		}
+	}
+	data, err := json.Marshal(blocks)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > MaxPromptBytes {
+		return nil, fmt.Errorf("%w: prompt exceeds size limit", ErrInvalidCommand)
+	}
+	return data, nil
+}
+
+func copyOperation(op Operation) Operation {
+	op.Command.Prompt = append(json.RawMessage(nil), op.Command.Prompt...)
+	return op
+}

--- a/server/experiments/agenttransport/content_test.go
+++ b/server/experiments/agenttransport/content_test.go
@@ -1,0 +1,81 @@
+package agenttransport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestContentRetryAndOwnership(t *testing.T) {
+	runner, server := setup(t)
+	original := json.RawMessage(`[{"type":"text","text":"hello","_meta":{"n":9007199254740993}}]`)
+	command := Command{"content", original}
+	submit(t, server, command, 202)
+	waitStarted(t, runner)
+	command.Prompt = json.RawMessage(`[ { "_meta": {"n":9007199254740993}, "text":"hello", "type":"text" } ]`)
+	submit(t, server, command, 202)
+	command.Prompt = json.RawMessage(`[{"type":"text","text":"hello","_meta":{"n":9007199254740994}}]`)
+	submit(t, server, command, 409)
+	if runner.executions.Load() != 1 {
+		t.Fatal("content retry dispatched twice")
+	}
+	close(runner.release)
+
+	// Neither the caller nor a runner may mutate the accepted command in memory.
+	runtime := NewReference(runnerFunc(func(_ context.Context, prompt json.RawMessage, _ *Turn) error {
+		prompt[0] = 'x'
+		return nil
+	}))
+	defer runtime.Close()
+	op, err := runtime.Submit(Command{"owned", original})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original[0] = 'x'
+	op.Command.Prompt[0] = 'x'
+	canonical := json.RawMessage(`[{"_meta":{"n":9007199254740993},"text":"hello","type":"text"}]`)
+	if _, err := runtime.Submit(Command{"owned", canonical}); err != nil {
+		t.Fatalf("accepted command was mutated: %v", err)
+	}
+	runtime.Close()
+	if !bytes.Equal(runtime.operations["owned"].Command.Prompt, canonical) {
+		t.Fatal("runner mutated durable command")
+	}
+}
+
+func TestInvalidPromptContent(t *testing.T) {
+	_, server := setup(t)
+	for _, prompt := range []string{`"legacy text"`, `null`, `[]`, `{}`, `[null]`, `[1]`, `[{}]`, `[{"type":1}]`} {
+		t.Run(prompt, func(t *testing.T) {
+			submit(t, server, Command{"invalid", json.RawMessage(prompt)}, http.StatusBadRequest)
+		})
+	}
+	if state := snapshot(t, server.URL); state.Sequence != 0 || len(state.Operations) != 0 {
+		t.Fatal("invalid content was accepted")
+	}
+	if _, err := normalizePrompt(json.RawMessage(`[{"type":"text"}] []`)); !errors.Is(err, ErrInvalidCommand) {
+		t.Fatal("trailing JSON accepted")
+	}
+}
+
+func TestPromptSizeLimit(t *testing.T) {
+	runtime := NewReference(runnerFunc(func(context.Context, json.RawMessage, *Turn) error {
+		t.Error("oversized prompt dispatched")
+		return nil
+	}))
+	server := httptest.NewServer(runtime)
+	defer func() { runtime.Close(); server.Close() }()
+	submit(t, server, Command{"oversized", TextPrompt(strings.Repeat("a", MaxPromptBytes))}, 400)
+	if state := snapshot(t, server.URL); state.Sequence != 0 {
+		t.Fatal("oversized prompt journaled")
+	}
+	expanded := json.RawMessage(`[{"type":"text","text":"` + strings.Repeat("<", MaxPromptBytes/6) + `"}]`)
+	if _, err := normalizePrompt(expanded); !errors.Is(err, ErrInvalidCommand) {
+		t.Fatal("canonical JSON exceeded the limit without rejection")
+	}
+}

--- a/server/experiments/agenttransport/harness/harness_test.go
+++ b/server/experiments/agenttransport/harness/harness_test.go
@@ -62,6 +62,7 @@ func TestDeterministicACP(t *testing.T) {
 	acceptance.Run(t, factory(false))
 	acceptance.RunCrash(t, factory(false))
 	acceptance.RunPermissions(t, factory(true))
+	acceptance.RunPermissionCrash(t, factory(true))
 }
 
 type harnessConfig struct {
@@ -138,6 +139,7 @@ func TestRealHarness(t *testing.T) {
 		t.Run("permissions", func(t *testing.T) { t.Skip("NOT VALIDATED: permissionACP configuration not provided") })
 	} else {
 		acceptance.RunPermissions(t, factory(*config.PermissionACP))
+		acceptance.RunPermissionCrash(t, factory(*config.PermissionACP))
 	}
 }
 func fixture(t *testing.T, dir string, config acp.Config, timeout time.Duration) acceptance.Fixture {
@@ -168,5 +170,5 @@ func fixture(t *testing.T, dir string, config acp.Config, timeout time.Duration)
 	}
 	server := httptest.NewServer(runtime)
 	t.Cleanup(func() { runtime.Close(); server.Close() })
-	return acceptance.Fixture{URL: server.URL, Probe: probe.Probe{Dir: dir}, Prompt: prompt, Dispatches: client.Dispatches, ForcedStops: client.ForcedStops, ProcessID: client.PID, Kill: client.Close, Timeout: timeout}
+	return acceptance.Fixture{URL: server.URL, Probe: probe.Probe{Dir: dir}, Prompt: prompt, Dispatches: client.Dispatches, ForcedStops: client.ForcedStops, ProcessID: client.PID, Kill: client.Kill, Timeout: timeout}
 }

--- a/server/experiments/agenttransport/harness/harness_test.go
+++ b/server/experiments/agenttransport/harness/harness_test.go
@@ -1,0 +1,172 @@
+package harness_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	transport "github.com/kernel/kernel-images/server/experiments/agenttransport"
+	"github.com/kernel/kernel-images/server/experiments/agenttransport/acceptance"
+	"github.com/kernel/kernel-images/server/experiments/agenttransport/acp"
+	"github.com/kernel/kernel-images/server/experiments/agenttransport/probe"
+)
+
+const prompt = "Use the acceptance-probe MCP server's checkpoint tool exactly once. Do not use shell commands or inspect files. Wait for the tool result, then reply ACCEPTANCE_COMPLETE."
+
+func TestFixtureProcess(t *testing.T) {
+	dir := os.Getenv("AGENT_FIXTURE_PROBE")
+	if dir == "" {
+		return
+	}
+	serve := probe.ServeACP
+	if os.Getenv("AGENT_FIXTURE_PERMISSION") == "1" {
+		serve = probe.ServePermissionACP
+	}
+	if err := serve(context.Background(), os.Stdin, os.Stdout, probe.Probe{Dir: dir}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+func TestDeterministicACP(t *testing.T) {
+	factory := func(permission bool) acceptance.Factory {
+		return func(t *testing.T) acceptance.Fixture {
+			dir := t.TempDir()
+			config := acp.Config{Command: os.Args[0], Args: []string{"-test.run=^TestFixtureProcess$"}, Cwd: dir, Env: []string{"AGENT_FIXTURE_PROBE=" + dir}}
+			if permission {
+				config.Env = append(config.Env, "AGENT_FIXTURE_PERMISSION=1")
+				t.Cleanup(func() {
+					if t.Failed() {
+						return
+					}
+					data, err := os.ReadFile(filepath.Join(dir, "events.jsonl"))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if bytes.Contains(data, []byte(`"kind":"cancelled"`)) && !bytes.Contains(data, []byte("cancelled checkpoint")) {
+						t.Fatal("ACP update emitted during cancellation was lost")
+					}
+				})
+			}
+			return fixture(t, dir, config, 30*time.Second)
+		}
+	}
+	acceptance.Run(t, factory(false))
+	acceptance.RunCrash(t, factory(false))
+	acceptance.RunPermissions(t, factory(true))
+}
+
+type harnessConfig struct {
+	Harness        string      `json:"harness"`
+	HarnessVersion string      `json:"harnessVersion"`
+	AdapterVersion string      `json:"adapterVersion"`
+	ACP            acp.Config  `json:"acp"`
+	PermissionACP  *acp.Config `json:"permissionACP,omitempty"`
+}
+
+// TestRealHarness is opt-in: a skipped test is NOT a compatibility pass. Each
+// invocation uses a supplied, pinned agent and actual MCP checkpoint tool.
+func TestRealHarness(t *testing.T) {
+	path := os.Getenv("AGENT_ACCEPTANCE_CONFIG")
+	if path == "" {
+		t.Skip("NOT VALIDATED: set AGENT_ACCEPTANCE_CONFIG to a pinned harness configuration")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config harnessConfig
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&config); err != nil {
+		t.Fatal(err)
+	}
+	if config.Harness == "" || config.HarnessVersion == "" || config.AdapterVersion == "" {
+		t.Fatal("harness, harnessVersion, and adapterVersion are required evidence")
+	}
+	executable := filepath.Join(t.TempDir(), "agent-probe")
+	build := exec.Command("go", "build", "-o", executable, "../cmd/agent-probe")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build probe: %v\n%s", err, output)
+	}
+	t.Logf("harness=%s declared_version=%s adapter_version=%s", config.Harness, config.HarnessVersion, config.AdapterVersion)
+	factory := func(base acp.Config) acceptance.Factory {
+		return func(t *testing.T) acceptance.Fixture {
+			dir := t.TempDir()
+			if root := os.Getenv("AGENT_ACCEPTANCE_EVIDENCE_DIR"); root != "" {
+				if err := os.MkdirAll(root, 0700); err != nil {
+					t.Fatal(err)
+				}
+				dir, err = os.MkdirTemp(root, "acceptance-")
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Logf("private evidence directory: %s", dir)
+			}
+			// Round trip so each subtest gets independent slices and maps.
+			copyData, _ := json.Marshal(base)
+			var agent acp.Config
+			_ = json.Unmarshal(copyData, &agent)
+			agent.Cwd = filepath.Join(dir, "workspace")
+			if err := os.Mkdir(agent.Cwd, 0700); err != nil {
+				t.Fatal(err)
+			}
+			replace := strings.NewReplacer("{workspace}", agent.Cwd, "{probeDir}", dir, "{probeCommand}", executable)
+			agent.Command = replace.Replace(agent.Command)
+			for i := range agent.Args {
+				agent.Args[i] = replace.Replace(agent.Args[i])
+			}
+			for i := range agent.Env {
+				agent.Env[i] = replace.Replace(agent.Env[i])
+			}
+			server, _ := json.Marshal(map[string]any{"name": "acceptance-probe", "command": executable, "args": []string{"--mode", "mcp", "--dir", dir}, "env": []any{}})
+			agent.MCPServers = append(agent.MCPServers, server)
+			return fixture(t, dir, agent, 2*time.Minute)
+		}
+	}
+	acceptance.Run(t, factory(config.ACP))
+	acceptance.RunCrash(t, factory(config.ACP))
+	if config.PermissionACP == nil {
+		t.Run("permissions", func(t *testing.T) { t.Skip("NOT VALIDATED: permissionACP configuration not provided") })
+	} else {
+		acceptance.RunPermissions(t, factory(*config.PermissionACP))
+	}
+}
+func fixture(t *testing.T, dir string, config acp.Config, timeout time.Duration) acceptance.Fixture {
+	t.Helper()
+	stderr, err := os.OpenFile(filepath.Join(dir, "agent.stderr"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { stderr.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	client, err := acp.Start(ctx, config, stderr)
+	if err != nil {
+		t.Fatalf("ACP startup failed: %v (inspect private agent.stderr)", err)
+	}
+	t.Cleanup(client.Close)
+	if err := os.WriteFile(filepath.Join(dir, "capabilities.json"), client.Capabilities, 0600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := transport.OpenFileStore(filepath.Join(dir, "events.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := transport.NewRuntime(client, store)
+	if err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(runtime)
+	t.Cleanup(func() { runtime.Close(); server.Close() })
+	return acceptance.Fixture{URL: server.URL, Probe: probe.Probe{Dir: dir}, Prompt: prompt, Dispatches: client.Dispatches, ProcessID: client.PID, Kill: client.Close, Timeout: timeout}
+}

--- a/server/experiments/agenttransport/harness/harness_test.go
+++ b/server/experiments/agenttransport/harness/harness_test.go
@@ -170,5 +170,5 @@ func fixture(t *testing.T, dir string, config acp.Config, timeout time.Duration)
 	}
 	server := httptest.NewServer(runtime)
 	t.Cleanup(func() { runtime.Close(); server.Close() })
-	return acceptance.Fixture{URL: server.URL, Probe: probe.Probe{Dir: dir}, Prompt: prompt, Dispatches: client.Dispatches, ForcedStops: client.ForcedStops, ProcessID: client.PID, Kill: client.Kill, Timeout: timeout}
+	return acceptance.Fixture{URL: server.URL, Probe: probe.Probe{Dir: dir}, Prompt: transport.TextPrompt(prompt), Dispatches: client.Dispatches, ForcedStops: client.ForcedStops, ProcessID: client.PID, Kill: client.Kill, Timeout: timeout}
 }

--- a/server/experiments/agenttransport/harness/harness_test.go
+++ b/server/experiments/agenttransport/harness/harness_test.go
@@ -168,5 +168,5 @@ func fixture(t *testing.T, dir string, config acp.Config, timeout time.Duration)
 	}
 	server := httptest.NewServer(runtime)
 	t.Cleanup(func() { runtime.Close(); server.Close() })
-	return acceptance.Fixture{URL: server.URL, Probe: probe.Probe{Dir: dir}, Prompt: prompt, Dispatches: client.Dispatches, ProcessID: client.PID, Kill: client.Close, Timeout: timeout}
+	return acceptance.Fixture{URL: server.URL, Probe: probe.Probe{Dir: dir}, Prompt: prompt, Dispatches: client.Dispatches, ForcedStops: client.ForcedStops, ProcessID: client.PID, Kill: client.Close, Timeout: timeout}
 }

--- a/server/experiments/agenttransport/http.go
+++ b/server/experiments/agenttransport/http.go
@@ -111,11 +111,10 @@ func (s *Reference) stream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	controller := http.NewResponseController(w)
-	flush := func() error { return controller.Flush() }
 	if err := controller.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
 		return
 	}
-	if err := flush(); err != nil {
+	if err := controller.Flush(); err != nil {
 		return
 	}
 	heartbeat := time.NewTicker(time.Second)
@@ -137,7 +136,7 @@ func (s *Reference) stream(w http.ResponseWriter, r *http.Request) {
 			if _, err := fmt.Fprintf(w, "id: %d\ndata: %s\n\n", event.Sequence, data); err != nil {
 				return
 			}
-			if err := flush(); err != nil {
+			if err := controller.Flush(); err != nil {
 				return
 			}
 			cursor = event.Sequence
@@ -153,7 +152,7 @@ func (s *Reference) stream(w http.ResponseWriter, r *http.Request) {
 			if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
 				return
 			}
-			if err := flush(); err != nil {
+			if err := controller.Flush(); err != nil {
 				return
 			}
 		}

--- a/server/experiments/agenttransport/http.go
+++ b/server/experiments/agenttransport/http.go
@@ -1,0 +1,161 @@
+package agenttransport
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+func decode(w http.ResponseWriter, r *http.Request, value any) bool {
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(value); err != nil {
+		http.Error(w, "invalid request", 400)
+		return false
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		http.Error(w, "expected one request", 400)
+		return false
+	}
+	return true
+}
+func sendError(w http.ResponseWriter, err error) {
+	status := http.StatusServiceUnavailable
+	if errors.Is(err, ErrConflict) {
+		status = http.StatusConflict
+	}
+	http.Error(w, http.StatusText(status), status)
+}
+func (s *Reference) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/commands":
+		var c Command
+		if !decode(w, r, &c) {
+			return
+		}
+		if c.ID == "" || c.Prompt == "" {
+			http.Error(w, "id and prompt required", 400)
+			return
+		}
+		op, err := s.Submit(c)
+		if err != nil {
+			sendError(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(202)
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": op.Command.ID, "state": op.State})
+	case r.Method == http.MethodPost && (r.URL.Path == "/permissions" || r.URL.Path == "/cancel"):
+		var c Control
+		if !decode(w, r, &c) {
+			return
+		}
+		permission := r.URL.Path == "/permissions"
+		if c.ID == "" || c.OperationID == "" || (permission && (c.RequestID == "" || c.OptionID == "")) || (!permission && (c.RequestID != "" || c.OptionID != "")) {
+			http.Error(w, "invalid control", 400)
+			return
+		}
+		if err := s.Control(c, permission); err != nil {
+			sendError(w, err)
+			return
+		}
+		w.WriteHeader(202)
+	case r.Method == http.MethodGet && r.URL.Path == "/snapshot":
+		s.mu.Lock()
+		if s.fault != nil || s.closed {
+			s.mu.Unlock()
+			sendError(w, ErrUnavailable)
+			return
+		}
+		data, err := json.Marshal(Snapshot{len(s.events), s.operations, s.permissions})
+		s.mu.Unlock()
+		if err != nil {
+			sendError(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	case r.Method == http.MethodGet && r.URL.Path == "/events":
+		s.stream(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+func (s *Reference) stream(w http.ResponseWriter, r *http.Request) {
+	cursor := 0
+	if value := r.Header.Get("Last-Event-ID"); value != "" {
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 0 {
+			http.Error(w, "invalid cursor", 400)
+			return
+		}
+		cursor = n
+	}
+	s.mu.Lock()
+	future := cursor > len(s.events)
+	unavailable := s.closed || s.fault != nil
+	s.mu.Unlock()
+	if unavailable {
+		sendError(w, ErrUnavailable)
+		return
+	}
+	if future {
+		http.Error(w, "cursor ahead of session", 409)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	controller := http.NewResponseController(w)
+	flush := func() error { return controller.Flush() }
+	if err := controller.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return
+	}
+	if err := flush(); err != nil {
+		return
+	}
+	heartbeat := time.NewTicker(time.Second)
+	defer heartbeat.Stop()
+	for {
+		s.mu.Lock()
+		batch := append([]Event(nil), s.events[cursor:]...)
+		changed := s.changed
+		stop := s.closed || s.fault != nil
+		s.mu.Unlock()
+		if stop {
+			return
+		}
+		for _, event := range batch {
+			data, _ := json.Marshal(event)
+			if err := controller.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				return
+			}
+			if _, err := fmt.Fprintf(w, "id: %d\ndata: %s\n\n", event.Sequence, data); err != nil {
+				return
+			}
+			if err := flush(); err != nil {
+				return
+			}
+			cursor = event.Sequence
+		}
+		select {
+		case <-r.Context().Done():
+			return
+		case <-changed:
+		case <-heartbeat.C:
+			if err := controller.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				return
+			}
+			if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+				return
+			}
+			if err := flush(); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/server/experiments/agenttransport/http.go
+++ b/server/experiments/agenttransport/http.go
@@ -11,7 +11,7 @@ import (
 )
 
 func decode(w http.ResponseWriter, r *http.Request, value any) bool {
-	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10))
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<20))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(value); err != nil {
 		http.Error(w, "invalid request", 400)
@@ -26,6 +26,9 @@ func decode(w http.ResponseWriter, r *http.Request, value any) bool {
 }
 func sendError(w http.ResponseWriter, err error) {
 	status := http.StatusServiceUnavailable
+	if errors.Is(err, ErrInvalidCommand) {
+		status = http.StatusBadRequest
+	}
 	if errors.Is(err, ErrConflict) {
 		status = http.StatusConflict
 	}
@@ -36,10 +39,6 @@ func (s *Reference) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case r.Method == http.MethodPost && r.URL.Path == "/commands":
 		var c Command
 		if !decode(w, r, &c) {
-			return
-		}
-		if c.ID == "" || c.Prompt == "" {
-			http.Error(w, "id and prompt required", 400)
 			return
 		}
 		op, err := s.Submit(c)

--- a/server/experiments/agenttransport/probe/probe.go
+++ b/server/experiments/agenttransport/probe/probe.go
@@ -1,0 +1,238 @@
+// Package probe supplies a controlled MCP tool and deterministic ACP peer for
+// the acceptance tests. Neither mode is a production agent or MCP server.
+package probe
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type Probe struct{ Dir string }
+
+func (p Probe) Count() (int, error) {
+	data, err := os.ReadFile(filepath.Join(p.Dir, "calls"))
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return strings.Count(string(data), "called\n"), nil
+}
+func (p Probe) Release() error {
+	return os.WriteFile(filepath.Join(p.Dir, "release"), []byte("release"), 0600)
+}
+func (p Probe) Wait(ctx context.Context) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		count, err := p.Count()
+		if err != nil {
+			return err
+		}
+		if count > 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+func (p Probe) Checkpoint(ctx context.Context) error {
+	file, err := os.OpenFile(filepath.Join(p.Dir, "calls"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	_, err = file.WriteString("called\n")
+	if err == nil {
+		err = file.Sync()
+	}
+	file.Close()
+	if err != nil {
+		return err
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		_, err := os.Stat(filepath.Join(p.Dir, "release"))
+		if err == nil {
+			return nil
+		}
+		if !os.IsNotExist(err) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+type request struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+	Result json.RawMessage `json:"result"`
+}
+
+func reply(out io.Writer, id json.RawMessage, result any) error {
+	return json.NewEncoder(out).Encode(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
+}
+func failure(out io.Writer, id json.RawMessage, text string) error {
+	return json.NewEncoder(out).Encode(map[string]any{"jsonrpc": "2.0", "id": id, "error": map[string]any{"code": -32601, "message": text}})
+}
+
+// ServeMCP implements only the tool surface needed by the tests. The checkpoint
+// records each invocation, then waits for the test controller's release file.
+func ServeMCP(ctx context.Context, in io.Reader, out io.Writer, p Probe) error {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 4096), 1<<20)
+	for scanner.Scan() {
+		var r request
+		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
+			return err
+		}
+		if len(r.ID) == 0 {
+			continue
+		}
+		var result any
+		switch r.Method {
+		case "initialize":
+			var params struct {
+				ProtocolVersion string `json:"protocolVersion"`
+			}
+			if err := json.Unmarshal(r.Params, &params); err != nil {
+				return err
+			}
+			result = map[string]any{"protocolVersion": params.ProtocolVersion, "capabilities": map[string]any{"tools": map[string]any{}}, "serverInfo": map[string]string{"name": "acceptance-probe", "version": "1"}}
+		case "ping":
+			result = map[string]any{}
+		case "tools/list":
+			result = map[string]any{"tools": []any{map[string]any{"name": "checkpoint", "description": "Acceptance-test checkpoint. Call exactly once when instructed; waits for the test controller to release it.", "inputSchema": map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}}}}
+		case "tools/call":
+			var params struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(r.Params, &params); err != nil {
+				return err
+			}
+			if params.Name != "checkpoint" {
+				if err := failure(out, r.ID, "unknown tool"); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := p.Checkpoint(ctx); err != nil {
+				return err
+			}
+			result = map[string]any{"content": []any{map[string]string{"type": "text", "text": "checkpoint released; reply ACCEPTANCE_COMPLETE"}}, "isError": false}
+		default:
+			if err := failure(out, r.ID, "unsupported MCP method"); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := reply(out, r.ID, result); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+func update(out io.Writer, text string) error {
+	return json.NewEncoder(out).Encode(map[string]any{"jsonrpc": "2.0", "method": "session/update", "params": map[string]any{"sessionId": "fixture-session", "update": map[string]any{"sessionUpdate": "agent_message_chunk", "content": map[string]string{"type": "text", "text": text}}}})
+}
+
+// ServeACP is a deterministic subprocess peer, not a model. It exercises the
+// same stdio client used for real harnesses, including complete ACP payloads.
+func ServeACP(ctx context.Context, in io.Reader, out io.Writer, p Probe) error {
+	return serveACP(ctx, in, out, p, false)
+}
+func ServePermissionACP(ctx context.Context, in io.Reader, out io.Writer, p Probe) error {
+	return serveACP(ctx, in, out, p, true)
+}
+func serveACP(ctx context.Context, in io.Reader, out io.Writer, p Probe, permission bool) error {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 4096), 1<<20)
+	for scanner.Scan() {
+		var r request
+		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
+			return err
+		}
+		switch r.Method {
+		case "initialize":
+			if err := reply(out, r.ID, map[string]any{"protocolVersion": 1, "agentCapabilities": map[string]any{}, "agentInfo": map[string]string{"name": "deterministic-fixture", "version": "1"}}); err != nil {
+				return err
+			}
+		case "session/new":
+			if err := reply(out, r.ID, map[string]string{"sessionId": "fixture-session"}); err != nil {
+				return err
+			}
+		case "session/prompt":
+			if permission {
+				permissionRequest := map[string]any{"jsonrpc": "2.0", "id": "permission-1", "method": "session/request_permission", "params": map[string]any{"sessionId": "fixture-session", "toolCall": map[string]any{"toolCallId": "checkpoint-1", "title": "checkpoint", "status": "pending"}, "options": []any{map[string]string{"optionId": "allow", "kind": "allow_once", "name": "Allow once"}}}}
+				if err := json.NewEncoder(out).Encode(permissionRequest); err != nil {
+					return err
+				}
+				if !scanner.Scan() {
+					return io.ErrUnexpectedEOF
+				}
+				var decision request
+				if err := json.Unmarshal(scanner.Bytes(), &decision); err != nil {
+					return err
+				}
+				var result struct {
+					Outcome struct {
+						Outcome  string `json:"outcome"`
+						OptionID string `json:"optionId"`
+					} `json:"outcome"`
+				}
+				_ = json.Unmarshal(decision.Result, &result)
+				if decision.Method == "session/cancel" || result.Outcome.Outcome == "cancelled" {
+					if err := update(out, "cancelled checkpoint"); err != nil {
+						return err
+					}
+					if err := reply(out, r.ID, map[string]string{"stopReason": "cancelled"}); err != nil {
+						return err
+					}
+					continue
+				}
+				if string(decision.ID) != `"permission-1"` || result.Outcome.OptionID != "allow" {
+					return errors.New("invalid permission response")
+				}
+			}
+			if err := update(out, "before checkpoint"); err != nil {
+				return err
+			}
+			if err := p.Checkpoint(ctx); err != nil {
+				return err
+			}
+			if err := update(out, "ACCEPTANCE_COMPLETE"); err != nil {
+				return err
+			}
+			if err := reply(out, r.ID, map[string]string{"stopReason": "end_turn"}); err != nil {
+				return err
+			}
+		case "session/cancel":
+			// A permission response may have completed cancellation already.
+			continue
+		default:
+			if len(r.ID) > 0 {
+				if err := failure(out, r.ID, fmt.Sprintf("unsupported fixture method %s", r.Method)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return scanner.Err()
+}

--- a/server/experiments/agenttransport/probe/probe_test.go
+++ b/server/experiments/agenttransport/probe/probe_test.go
@@ -1,0 +1,77 @@
+package probe
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestMCPToolBarrier(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	input, writer := io.Pipe()
+	output, reader := io.Pipe()
+	t.Cleanup(func() { cancel(); writer.Close(); input.Close(); reader.Close(); output.Close() })
+	go func() { <-ctx.Done(); input.Close(); output.Close() }()
+	p := Probe{Dir: t.TempDir()}
+	done := make(chan error, 1)
+	go func() { done <- ServeMCP(ctx, input, reader, p) }()
+	encoder := json.NewEncoder(writer)
+	decoder := json.NewDecoder(bufio.NewReader(output))
+	send := func(id int, method string, params any) {
+		t.Helper()
+		if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	receive := func() map[string]json.RawMessage {
+		t.Helper()
+		var result map[string]json.RawMessage
+		if err := decoder.Decode(&result); err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	send(1, "initialize", map[string]string{"protocolVersion": "2025-03-26"})
+	var initialized struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := json.Unmarshal(receive()["result"], &initialized); err != nil || initialized.ProtocolVersion != "2025-03-26" {
+		t.Fatal("MCP version negotiation failed")
+	}
+	send(2, "tools/list", map[string]any{})
+	var listed struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(receive()["result"], &listed); err != nil || len(listed.Tools) != 1 || listed.Tools[0].Name != "checkpoint" {
+		t.Fatal("missing checkpoint tool")
+	}
+	send(3, "tools/call", map[string]any{"name": "checkpoint", "arguments": map[string]any{}})
+	if err := p.Wait(ctx); err != nil {
+		t.Fatal(err)
+	}
+	count, err := p.Count()
+	if err != nil || count != 1 {
+		t.Fatalf("tool count %d: %v", count, err)
+	}
+	if err := p.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if len(receive()["error"]) != 0 {
+		t.Fatal("tool invocation failed")
+	}
+	writer.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+}

--- a/server/experiments/agenttransport/recovery_test.go
+++ b/server/experiments/agenttransport/recovery_test.go
@@ -75,7 +75,7 @@ func postControl(t *testing.T, url, path string, c Control, status int) {
 func TestPermissionDetachAndDecisionRetry(t *testing.T) {
 	var effects atomic.Int32
 	runtime := NewReference(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
-		option, err := turn.Permission("approval", json.RawMessage(`{"options":[{"optionId":"yes","kind":"allow_once","name":"Allow"},{"optionId":"no","kind":"reject_once","name":"Reject"}]}`))
+		option, err := turn.Permission(ctx, "approval", json.RawMessage(`{"options":[{"optionId":"yes","kind":"allow_once","name":"Allow"},{"optionId":"no","kind":"reject_once","name":"Reject"}]}`))
 		if err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func TestPermissionDetachAndDecisionRetry(t *testing.T) {
 func TestCancelPendingPermissionAndRetry(t *testing.T) {
 	var effects atomic.Int32
 	runtime := NewReference(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
-		_, err := turn.Permission("approval", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
+		_, err := turn.Permission(ctx, "approval", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
 		if err == nil {
 			effects.Add(1)
 		}
@@ -187,7 +187,7 @@ func TestPermissionPersistenceFailureNeverApproves(t *testing.T) {
 	var effects atomic.Int32
 	store := &failingStore{failAt: 3}
 	runtime, err := NewRuntime(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
-		_, err := turn.Permission("p", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
+		_, err := turn.Permission(ctx, "p", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
 		if err == nil {
 			effects.Add(1)
 		}
@@ -235,7 +235,7 @@ func TestCrashHelper(t *testing.T) {
 				return nil
 			}
 			if stage == "permission" {
-				_, err := turn.Permission("p", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
+				_, err := turn.Permission(ctx, "p", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
 				return err
 			}
 			if err := turn.Output("started"); err != nil {

--- a/server/experiments/agenttransport/recovery_test.go
+++ b/server/experiments/agenttransport/recovery_test.go
@@ -1,0 +1,368 @@
+package agenttransport
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type runnerFunc func(context.Context, string, *Turn) error
+
+func (f runnerFunc) Run(ctx context.Context, prompt string, turn *Turn) error {
+	return f(ctx, prompt, turn)
+}
+
+func snapshot(t *testing.T, url string) Snapshot {
+	t.Helper()
+	response, err := (&http.Client{Timeout: 5 * time.Second}).Get(url + "/snapshot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != 200 {
+		t.Fatalf("snapshot: %d", response.StatusCode)
+	}
+	var result Snapshot
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+func await(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	for {
+		if condition() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("condition timed out")
+		case <-tick.C:
+		}
+	}
+}
+func postControl(t *testing.T, url, path string, c Control, status int) {
+	t.Helper()
+	data, _ := json.Marshal(c)
+	req, err := http.NewRequest("POST", url+path, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != status {
+		t.Fatalf("%s: got %d want %d", path, response.StatusCode, status)
+	}
+}
+
+func TestPermissionDetachAndDecisionRetry(t *testing.T) {
+	var effects atomic.Int32
+	runtime := NewReference(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
+		option, err := turn.Permission("approval", json.RawMessage(`{"options":[{"optionId":"yes","kind":"allow_once","name":"Allow"},{"optionId":"no","kind":"reject_once","name":"Reject"}]}`))
+		if err != nil {
+			return err
+		}
+		if option == "yes" {
+			effects.Add(1)
+		}
+		return nil
+	}))
+	server := httptest.NewServer(runtime)
+	t.Cleanup(func() { runtime.Close(); server.Close() })
+	response, scanner := subscribe(t, server, 0)
+	submit(t, server, Command{"permission", "use a tool"}, 202)
+	next(t, scanner)
+	request := next(t, scanner)
+	if request.Kind != "permission_request" {
+		t.Fatalf("unexpected request %+v", request)
+	}
+	response.Body.Close()
+	if effects.Load() != 0 {
+		t.Fatal("permission was implicitly approved")
+	}
+	if len(snapshot(t, server.URL).Permissions) != 1 {
+		t.Fatal("pending permission missing")
+	}
+	_, scanner = subscribe(t, server, 1)
+	replay := next(t, scanner)
+	if replay.RequestID != request.RequestID {
+		t.Fatal("request identity changed")
+	}
+	decision := Control{"decision-1", "permission", request.RequestID, "yes"}
+	invalid := decision
+	invalid.OptionID = "invented"
+	postControl(t, server.URL, "/permissions", invalid, 409)
+	postControl(t, server.URL, "/permissions", decision, 202)
+	postControl(t, server.URL, "/permissions", decision, 202)
+	invalid = decision
+	invalid.OptionID = "no"
+	postControl(t, server.URL, "/permissions", invalid, 409)
+	await(t, func() bool { return snapshot(t, server.URL).Operations["permission"].State == "completed" })
+	if effects.Load() != 1 {
+		t.Fatalf("effects: %d", effects.Load())
+	}
+	if len(snapshot(t, server.URL).Permissions) != 0 {
+		t.Fatal("resolved permission retained")
+	}
+}
+
+func TestCancelPendingPermissionAndRetry(t *testing.T) {
+	var effects atomic.Int32
+	runtime := NewReference(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
+		_, err := turn.Permission("approval", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
+		if err == nil {
+			effects.Add(1)
+		}
+		return err
+	}))
+	server := httptest.NewServer(runtime)
+	t.Cleanup(func() { runtime.Close(); server.Close() })
+	submit(t, server, Command{"cancel-me", "use a tool"}, 202)
+	await(t, func() bool { return len(snapshot(t, server.URL).Permissions) == 1 })
+	cancel := Control{ID: "cancel-1", OperationID: "cancel-me"}
+	postControl(t, server.URL, "/cancel", cancel, 202)
+	await(t, func() bool { return snapshot(t, server.URL).Operations["cancel-me"].State == "cancelled" })
+	postControl(t, server.URL, "/cancel", cancel, 202)
+	postControl(t, server.URL, "/permissions", Control{"late-decision", "cancel-me", `["cancel-me","approval"]`, "yes"}, 409)
+	if effects.Load() != 0 {
+		t.Fatal("cancelled permission executed")
+	}
+	_, scanner := subscribe(t, server, 0)
+	for _, kind := range []string{"accepted", "permission_request", "cancel_requested", "cancelled"} {
+		if e := next(t, scanner); e.Kind != kind {
+			t.Fatalf("got %+v want %s", e, kind)
+		}
+	}
+}
+
+type failingStore struct {
+	MemoryStore
+	failAt int
+	writes int
+}
+
+func (s *failingStore) Append(e Event) error {
+	s.writes++
+	if s.writes == s.failAt {
+		return errors.New("injected disk failure")
+	}
+	return s.MemoryStore.Append(e)
+}
+func TestPersistenceFailurePreventsDispatch(t *testing.T) {
+	var calls atomic.Int32
+	store := &failingStore{failAt: 1}
+	runtime, err := NewRuntime(runnerFunc(func(context.Context, string, *Turn) error { calls.Add(1); return nil }), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Close()
+	if _, err := runtime.Submit(Command{"op", "prompt"}); !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("got %v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatal("dispatched an uncommitted command")
+	}
+	if len(store.events) != 0 {
+		t.Fatal("uncommitted event visible")
+	}
+}
+func TestPermissionPersistenceFailureNeverApproves(t *testing.T) {
+	var effects atomic.Int32
+	store := &failingStore{failAt: 3}
+	runtime, err := NewRuntime(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
+		_, err := turn.Permission("p", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
+		if err == nil {
+			effects.Add(1)
+		}
+		return err
+	}), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(runtime)
+	t.Cleanup(func() { runtime.Close(); server.Close() })
+	submit(t, server, Command{"op", "prompt"}, 202)
+	await(t, func() bool { return len(snapshot(t, server.URL).Permissions) == 1 })
+	postControl(t, server.URL, "/permissions", Control{"decision", "op", `["op","p"]`, "yes"}, 503)
+	runtime.Close()
+	if effects.Load() != 0 {
+		t.Fatal("approved an uncommitted decision")
+	}
+	if len(store.events) != 2 {
+		t.Fatalf("uncommitted events visible: %d", len(store.events))
+	}
+}
+
+// The helper is killed, not gracefully closed, so no shutdown event can mask an
+// ambiguous dispatch. The journal is reopened by an entirely different process.
+func TestCrashHelper(t *testing.T) {
+	path, stage := os.Getenv("AGENT_JOURNAL_HELPER"), os.Getenv("AGENT_JOURNAL_STAGE")
+	if path == "" {
+		return
+	}
+	store, err := OpenFileStore(path)
+	if err != nil {
+		panic(err)
+	}
+	if stage == "accepted" {
+		c := Command{"crash-op", "prompt"}
+		if err := store.Append(Event{Sequence: 1, OperationID: c.ID, Kind: "accepted", Command: &c}); err != nil {
+			panic(err)
+		}
+	} else {
+		runtime, err := NewRuntime(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
+			if err := os.WriteFile(path+".effect", []byte("executed"), 0600); err != nil {
+				return err
+			}
+			if stage == "completed" {
+				return nil
+			}
+			if stage == "permission" {
+				_, err := turn.Permission("p", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
+				return err
+			}
+			if err := turn.Output("started"); err != nil {
+				return err
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		}), store)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := runtime.Submit(Command{"crash-op", "prompt"}); err != nil {
+			panic(err)
+		}
+		for {
+			runtime.mu.Lock()
+			ready := (stage == "completed" && runtime.operations["crash-op"].State == "completed") || (stage == "permission" && len(runtime.permissions) == 1) || (stage == "tool-start" && len(runtime.events) == 2)
+			runtime.mu.Unlock()
+			if ready {
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+	fmt.Println("READY")
+	select {}
+}
+func TestJournalRecoveryAfterProcessKill(t *testing.T) {
+	for _, stage := range []string{"accepted", "tool-start", "permission", "completed"} {
+		t.Run(stage, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "events.jsonl")
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestCrashHelper$")
+			cmd.Env = append(os.Environ(), "AGENT_JOURNAL_HELPER="+path, "AGENT_JOURNAL_STAGE="+stage)
+			stdout, err := cmd.StdoutPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd.Stderr = os.Stderr
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = cmd.Process.Kill() })
+			scanner := bufio.NewScanner(stdout)
+			if !scanner.Scan() || scanner.Text() != "READY" {
+				t.Fatalf("helper not ready: %v", scanner.Err())
+			}
+			if err := cmd.Process.Kill(); err != nil {
+				t.Fatal(err)
+			}
+			_ = cmd.Wait()
+			store, err := OpenFileStore(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var replayed atomic.Int32
+			runtime, err := NewRuntime(runnerFunc(func(context.Context, string, *Turn) error { replayed.Add(1); return nil }), store)
+			if err != nil {
+				store.Close()
+				t.Fatal(err)
+			}
+			defer runtime.Close()
+			op, err := runtime.Submit(Command{"crash-op", "prompt"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected := "uncertain"
+			if stage == "completed" {
+				expected = "completed"
+			}
+			if op.State != expected {
+				t.Fatalf("got %s want %s", op.State, expected)
+			}
+			if replayed.Load() != 0 {
+				t.Fatal("automatically replayed a recovered operation")
+			}
+			if len(runtime.permissions) != 0 {
+				t.Fatal("stale permission remains actionable after restart")
+			}
+			if expected == "uncertain" {
+				if _, err := runtime.Submit(Command{"new", "new prompt"}); !errors.Is(err, ErrConflict) {
+					t.Fatal("uncertain session accepted new work")
+				}
+			}
+		})
+	}
+}
+
+func TestJournalLockAndTornTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	store, err := OpenFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other, err := OpenFileStore(path); err == nil {
+		other.Close()
+		t.Fatal("second journal owner accepted")
+	}
+	c := Command{"op", "prompt"}
+	if err := store.Append(Event{Sequence: 1, OperationID: "op", Kind: "accepted", Command: &c}); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = file.WriteString(`{"sequence":2`)
+	file.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err = OpenFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.Load()
+	store.Close()
+	if err != nil || len(events) != 1 {
+		t.Fatalf("torn tail recovery: %v %d", err, len(events))
+	}
+	if err := os.WriteFile(path, []byte("not-json\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if store, err := OpenFileStore(path); err == nil {
+		store.Close()
+		t.Fatal("complete corrupt record accepted")
+	}
+}

--- a/server/experiments/agenttransport/recovery_test.go
+++ b/server/experiments/agenttransport/recovery_test.go
@@ -17,9 +17,9 @@ import (
 	"time"
 )
 
-type runnerFunc func(context.Context, string, *Turn) error
+type runnerFunc func(context.Context, json.RawMessage, *Turn) error
 
-func (f runnerFunc) Run(ctx context.Context, prompt string, turn *Turn) error {
+func (f runnerFunc) Run(ctx context.Context, prompt json.RawMessage, turn *Turn) error {
 	return f(ctx, prompt, turn)
 }
 
@@ -74,7 +74,7 @@ func postControl(t *testing.T, url, path string, c Control, status int) {
 
 func TestPermissionDetachAndDecisionRetry(t *testing.T) {
 	var effects atomic.Int32
-	runtime := NewReference(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
+	runtime := NewReference(runnerFunc(func(ctx context.Context, prompt json.RawMessage, turn *Turn) error {
 		option, err := turn.Permission(ctx, "approval", json.RawMessage(`{"options":[{"optionId":"yes","kind":"allow_once","name":"Allow"},{"optionId":"no","kind":"reject_once","name":"Reject"}]}`))
 		if err != nil {
 			return err
@@ -87,7 +87,7 @@ func TestPermissionDetachAndDecisionRetry(t *testing.T) {
 	server := httptest.NewServer(runtime)
 	t.Cleanup(func() { runtime.Close(); server.Close() })
 	response, scanner := subscribe(t, server, 0)
-	submit(t, server, Command{"permission", "use a tool"}, 202)
+	submit(t, server, Command{"permission", TextPrompt("use a tool")}, 202)
 	next(t, scanner)
 	request := next(t, scanner)
 	if request.Kind != "permission_request" {
@@ -125,7 +125,7 @@ func TestPermissionDetachAndDecisionRetry(t *testing.T) {
 
 func TestCancelPendingPermissionAndRetry(t *testing.T) {
 	var effects atomic.Int32
-	runtime := NewReference(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
+	runtime := NewReference(runnerFunc(func(ctx context.Context, prompt json.RawMessage, turn *Turn) error {
 		_, err := turn.Permission(ctx, "approval", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
 		if err == nil {
 			effects.Add(1)
@@ -134,7 +134,7 @@ func TestCancelPendingPermissionAndRetry(t *testing.T) {
 	}))
 	server := httptest.NewServer(runtime)
 	t.Cleanup(func() { runtime.Close(); server.Close() })
-	submit(t, server, Command{"cancel-me", "use a tool"}, 202)
+	submit(t, server, Command{"cancel-me", TextPrompt("use a tool")}, 202)
 	await(t, func() bool { return len(snapshot(t, server.URL).Permissions) == 1 })
 	cancel := Control{ID: "cancel-1", OperationID: "cancel-me"}
 	postControl(t, server.URL, "/cancel", cancel, 202)
@@ -168,12 +168,12 @@ func (s *failingStore) Append(e Event) error {
 func TestPersistenceFailurePreventsDispatch(t *testing.T) {
 	var calls atomic.Int32
 	store := &failingStore{failAt: 1}
-	runtime, err := NewRuntime(runnerFunc(func(context.Context, string, *Turn) error { calls.Add(1); return nil }), store)
+	runtime, err := NewRuntime(runnerFunc(func(context.Context, json.RawMessage, *Turn) error { calls.Add(1); return nil }), store)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer runtime.Close()
-	if _, err := runtime.Submit(Command{"op", "prompt"}); !errors.Is(err, ErrUnavailable) {
+	if _, err := runtime.Submit(Command{"op", TextPrompt("prompt")}); !errors.Is(err, ErrUnavailable) {
 		t.Fatalf("got %v", err)
 	}
 	if calls.Load() != 0 {
@@ -186,7 +186,7 @@ func TestPersistenceFailurePreventsDispatch(t *testing.T) {
 func TestPermissionPersistenceFailureNeverApproves(t *testing.T) {
 	var effects atomic.Int32
 	store := &failingStore{failAt: 3}
-	runtime, err := NewRuntime(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
+	runtime, err := NewRuntime(runnerFunc(func(ctx context.Context, prompt json.RawMessage, turn *Turn) error {
 		_, err := turn.Permission(ctx, "p", json.RawMessage(`{"options":[{"optionId":"yes"}]}`))
 		if err == nil {
 			effects.Add(1)
@@ -198,7 +198,7 @@ func TestPermissionPersistenceFailureNeverApproves(t *testing.T) {
 	}
 	server := httptest.NewServer(runtime)
 	t.Cleanup(func() { runtime.Close(); server.Close() })
-	submit(t, server, Command{"op", "prompt"}, 202)
+	submit(t, server, Command{"op", TextPrompt("prompt")}, 202)
 	await(t, func() bool { return len(snapshot(t, server.URL).Permissions) == 1 })
 	postControl(t, server.URL, "/permissions", Control{"decision", "op", `["op","p"]`, "yes"}, 503)
 	runtime.Close()
@@ -222,12 +222,12 @@ func TestCrashHelper(t *testing.T) {
 		panic(err)
 	}
 	if stage == "accepted" {
-		c := Command{"crash-op", "prompt"}
+		c := Command{"crash-op", TextPrompt("prompt")}
 		if err := store.Append(Event{Sequence: 1, OperationID: c.ID, Kind: "accepted", Command: &c}); err != nil {
 			panic(err)
 		}
 	} else {
-		runtime, err := NewRuntime(runnerFunc(func(ctx context.Context, prompt string, turn *Turn) error {
+		runtime, err := NewRuntime(runnerFunc(func(ctx context.Context, prompt json.RawMessage, turn *Turn) error {
 			if err := os.WriteFile(path+".effect", []byte("executed"), 0600); err != nil {
 				return err
 			}
@@ -247,7 +247,7 @@ func TestCrashHelper(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		if _, err := runtime.Submit(Command{"crash-op", "prompt"}); err != nil {
+		if _, err := runtime.Submit(Command{"crash-op", TextPrompt("prompt")}); err != nil {
 			panic(err)
 		}
 		for {
@@ -293,13 +293,13 @@ func TestJournalRecoveryAfterProcessKill(t *testing.T) {
 				t.Fatal(err)
 			}
 			var replayed atomic.Int32
-			runtime, err := NewRuntime(runnerFunc(func(context.Context, string, *Turn) error { replayed.Add(1); return nil }), store)
+			runtime, err := NewRuntime(runnerFunc(func(context.Context, json.RawMessage, *Turn) error { replayed.Add(1); return nil }), store)
 			if err != nil {
 				store.Close()
 				t.Fatal(err)
 			}
 			defer runtime.Close()
-			op, err := runtime.Submit(Command{"crash-op", "prompt"})
+			op, err := runtime.Submit(Command{"crash-op", TextPrompt("prompt")})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -317,7 +317,7 @@ func TestJournalRecoveryAfterProcessKill(t *testing.T) {
 				t.Fatal("stale permission remains actionable after restart")
 			}
 			if expected == "uncertain" {
-				if _, err := runtime.Submit(Command{"new", "new prompt"}); !errors.Is(err, ErrConflict) {
+				if _, err := runtime.Submit(Command{"new", TextPrompt("new prompt")}); !errors.Is(err, ErrConflict) {
 					t.Fatal("uncertain session accepted new work")
 				}
 			}
@@ -335,7 +335,7 @@ func TestJournalLockAndTornTail(t *testing.T) {
 		other.Close()
 		t.Fatal("second journal owner accepted")
 	}
-	c := Command{"op", "prompt"}
+	c := Command{"op", TextPrompt("prompt")}
 	if err := store.Append(Event{Sequence: 1, OperationID: "op", Kind: "accepted", Command: &c}); err != nil {
 		t.Fatal(err)
 	}

--- a/server/experiments/agenttransport/reference.go
+++ b/server/experiments/agenttransport/reference.go
@@ -1,14 +1,12 @@
-// Package agenttransport contains an experimental reconnect contract, not a
-// production endpoint. State survives client disconnects, not process restarts.
+// Package agenttransport implements an experimental, single-session reconnect
+// contract. It is not registered in the image server's production router.
 package agenttransport
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"strconv"
 	"sync"
 )
 
@@ -16,166 +14,327 @@ type Command struct {
 	ID     string `json:"id"`
 	Prompt string `json:"prompt"`
 }
-
-type Event struct {
-	Sequence    int    `json:"sequence"`
+type Control struct {
+	ID          string `json:"id"`
 	OperationID string `json:"operationId"`
-	Kind        string `json:"kind"`
-	Text        string `json:"text,omitempty"`
+	RequestID   string `json:"requestId,omitempty"`
+	OptionID    string `json:"optionId,omitempty"`
 }
-
-// Runner executes one accepted prompt. Its context belongs to the runtime,
-// never to the HTTP request. Emit must finish before Run returns.
+type Event struct {
+	Sequence    int             `json:"sequence"`
+	OperationID string          `json:"operationId"`
+	Kind        string          `json:"kind"`
+	Text        string          `json:"text,omitempty"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
+	Command     *Command        `json:"command,omitempty"`
+	Control     *Control        `json:"control,omitempty"`
+	RequestID   string          `json:"requestId,omitempty"`
+}
 type Runner interface {
-	Run(context.Context, string, func(string)) error
+	Run(context.Context, string, *Turn) error
+}
+type Operation struct {
+	Command Command `json:"command"`
+	State   string  `json:"state"`
+}
+type PendingPermission struct {
+	OperationID string          `json:"operationId"`
+	RequestID   string          `json:"requestId"`
+	Payload     json.RawMessage `json:"payload"`
+}
+type Snapshot struct {
+	Sequence    int                          `json:"sequence"`
+	Operations  map[string]Operation         `json:"operations"`
+	Permissions map[string]PendingPermission `json:"permissions"`
 }
 
-type operation struct {
-	command Command
-	state   string
-}
-
-// Reference is a single-session, in-memory transport used to test the contract.
-// It deliberately does not implement ACP or authenticate network callers.
 type Reference struct {
-	ctx        context.Context
-	cancel     context.CancelFunc
-	runner     Runner
-	mu         sync.Mutex
-	operations map[string]operation
-	events     []Event
-	changed    chan struct{}
-	workers    sync.WaitGroup
-	closed     bool
+	runner      Runner
+	store       Store
+	mu          sync.Mutex
+	operations  map[string]Operation
+	controls    map[string]Control
+	permissions map[string]PendingPermission
+	decisions   map[string]string
+	events      []Event
+	changed     chan struct{}
+	workers     sync.WaitGroup
+	cancels     map[string]context.CancelFunc
+	closed      bool
+	fault       error
 }
 
 func NewReference(runner Runner) *Reference {
-	ctx, cancel := context.WithCancel(context.Background())
-	return &Reference{ctx: ctx, cancel: cancel, runner: runner, operations: make(map[string]operation), changed: make(chan struct{})}
+	runtime, err := NewRuntime(runner, &MemoryStore{})
+	if err != nil {
+		panic(err)
+	}
+	return runtime
+}
+
+// NewRuntime takes ownership of store on success. In-flight journal entries are
+// uncertain after restart; they are never automatically sent to the agent again.
+func NewRuntime(runner Runner, store Store) (*Reference, error) {
+	s := &Reference{runner: runner, store: store, operations: make(map[string]Operation), controls: make(map[string]Control), permissions: make(map[string]PendingPermission), decisions: make(map[string]string), changed: make(chan struct{}), cancels: make(map[string]context.CancelFunc)}
+	events, err := store.Load()
+	if err != nil {
+		return nil, err
+	}
+	for _, event := range events {
+		if err := s.apply(event); err != nil {
+			return nil, err
+		}
+		s.events = append(s.events, event)
+	}
+	for id, op := range s.operations {
+		if op.State == "running" || op.State == "cancelling" {
+			if err := s.record(Event{OperationID: id, Kind: "uncertain", Text: "runtime restarted before a terminal result was committed"}); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return s, nil
 }
 
 func (s *Reference) Close() {
 	s.mu.Lock()
 	s.closed = true
-	s.cancel()
-	s.mu.Unlock()
-	s.workers.Wait()
-}
-
-func (s *Reference) appendLocked(id, kind, text string) {
-	s.events = append(s.events, Event{len(s.events) + 1, id, kind, text})
+	for _, cancel := range s.cancels {
+		cancel()
+	}
 	close(s.changed)
 	s.changed = make(chan struct{})
+	s.mu.Unlock()
+	s.workers.Wait()
+	_ = s.store.Close()
 }
 
-func (s *Reference) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch {
-	case r.Method == http.MethodPost && r.URL.Path == "/commands":
-		s.submit(w, r)
-	case r.Method == http.MethodGet && r.URL.Path == "/events":
-		s.stream(w, r)
-	default:
-		http.NotFound(w, r)
+// record is called under mu (or during construction). No event becomes visible
+// and no side effect is released until the journal accepts the record.
+func (s *Reference) record(event Event) error {
+	if s.fault != nil {
+		return s.fault
 	}
-}
-
-func (s *Reference) submit(w http.ResponseWriter, r *http.Request) {
-	var c Command
-	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10))
-	if err := decoder.Decode(&c); err != nil || c.ID == "" || c.Prompt == "" {
-		http.Error(w, "invalid command", http.StatusBadRequest)
-		return
-	}
-	var extra any
-	if err := decoder.Decode(&extra); err != io.EOF {
-		http.Error(w, "expected one command", http.StatusBadRequest)
-		return
-	}
-	s.mu.Lock()
-	if s.closed {
-		s.mu.Unlock()
-		http.Error(w, "runtime closed", http.StatusServiceUnavailable)
-		return
-	}
-	if existing, ok := s.operations[c.ID]; ok {
-		s.mu.Unlock()
-		if existing.command != c {
-			http.Error(w, "operation ID reused with different payload", http.StatusConflict)
-			return
+	event.Sequence = len(s.events) + 1
+	// Copy payload ownership: an adapter can reuse its decode buffers.
+	event.Payload = append(json.RawMessage(nil), event.Payload...)
+	if err := s.store.Append(event); err != nil {
+		s.fault = err
+		for _, cancel := range s.cancels {
+			cancel()
 		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusAccepted)
-		_ = json.NewEncoder(w).Encode(map[string]string{"id": c.ID, "state": existing.state})
-		return
+		close(s.changed)
+		s.changed = make(chan struct{})
+		return err
 	}
-	s.operations[c.ID] = operation{c, "running"}
-	s.appendLocked(c.ID, "accepted", "")
+	if err := s.apply(event); err != nil {
+		s.fault = err
+		return err
+	}
+	s.events = append(s.events, event)
+	close(s.changed)
+	s.changed = make(chan struct{})
+	return nil
+}
+
+func (s *Reference) apply(e Event) error {
+	switch e.Kind {
+	case "accepted":
+		if e.Command == nil || e.Command.ID != e.OperationID {
+			return errors.New("invalid accepted event")
+		}
+		s.operations[e.OperationID] = Operation{*e.Command, "running"}
+	case "completed", "failed", "cancelled", "uncertain":
+		op, ok := s.operations[e.OperationID]
+		if !ok {
+			return errors.New("terminal event without operation")
+		}
+		op.State = e.Kind
+		s.operations[e.OperationID] = op
+		for id, p := range s.permissions {
+			if p.OperationID == e.OperationID {
+				delete(s.permissions, id)
+			}
+		}
+	case "permission_request":
+		s.permissions[e.RequestID] = PendingPermission{e.OperationID, e.RequestID, e.Payload}
+	case "permission_resolved":
+		if e.Control == nil {
+			return errors.New("permission decision without control")
+		}
+		s.controls[e.Control.ID] = *e.Control
+		s.decisions[e.RequestID] = e.Control.OptionID
+		delete(s.permissions, e.RequestID)
+	case "cancel_requested":
+		if e.Control == nil {
+			return errors.New("cancellation without control")
+		}
+		s.controls[e.Control.ID] = *e.Control
+		op := s.operations[e.OperationID]
+		op.State = "cancelling"
+		s.operations[e.OperationID] = op
+	case "output", "acp":
+	default:
+		return fmt.Errorf("unknown journal event %q", e.Kind)
+	}
+	return nil
+}
+
+var ErrConflict = errors.New("operation conflict")
+var ErrUnavailable = errors.New("runtime unavailable")
+var ErrUncertain = errors.New("agent outcome uncertain")
+
+func (s *Reference) Submit(c Command) (Operation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.fault != nil {
+		return Operation{}, ErrUnavailable
+	}
+	if op, ok := s.operations[c.ID]; ok {
+		if op.Command != c {
+			return Operation{}, ErrConflict
+		}
+		return op, nil
+	}
+	for _, op := range s.operations {
+		if op.State == "running" || op.State == "cancelling" || op.State == "uncertain" {
+			return Operation{}, ErrConflict
+		}
+	}
+	if err := s.record(Event{OperationID: c.ID, Kind: "accepted", Command: &c}); err != nil {
+		return Operation{}, ErrUnavailable
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancels[c.ID] = cancel
 	s.workers.Add(1)
 	go func() {
 		defer s.workers.Done()
-		err := s.runner.Run(s.ctx, c.Prompt, func(text string) {
-			s.mu.Lock()
-			defer s.mu.Unlock()
-			s.appendLocked(c.ID, "output", text)
-		})
+		defer cancel()
+		err := s.runner.Run(ctx, c.Prompt, &Turn{s: s, id: c.ID, ctx: ctx})
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		state, text := "completed", ""
-		if err != nil {
+		if ctx.Err() != nil {
+			state = "cancelled"
+		} else if errors.Is(err, ErrUncertain) {
+			state, text = "uncertain", err.Error()
+		} else if err != nil {
 			state, text = "failed", err.Error()
 		}
-		s.operations[c.ID] = operation{c, state}
-		s.appendLocked(c.ID, state, text)
+		_ = s.record(Event{OperationID: c.ID, Kind: state, Text: text})
+		delete(s.cancels, c.ID)
 	}()
-	s.mu.Unlock()
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	_ = json.NewEncoder(w).Encode(map[string]string{"id": c.ID, "state": "running"})
+	return s.operations[c.ID], nil
 }
 
-func (s *Reference) stream(w http.ResponseWriter, r *http.Request) {
-	cursor := 0
-	if value := r.Header.Get("Last-Event-ID"); value != "" {
-		n, err := strconv.Atoi(value)
-		if err != nil || n < 0 {
-			http.Error(w, "invalid cursor", http.StatusBadRequest)
-			return
-		}
-		cursor = n
-	}
+func (s *Reference) Control(c Control, permission bool) error {
 	s.mu.Lock()
-	future := cursor > len(s.events)
-	s.mu.Unlock()
-	if future {
-		http.Error(w, "cursor ahead of session", http.StatusConflict)
-		return
+	defer s.mu.Unlock()
+	if s.closed || s.fault != nil {
+		return ErrUnavailable
 	}
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	controller := http.NewResponseController(w)
-	if err := controller.Flush(); err != nil {
-		return
+	if prior, ok := s.controls[c.ID]; ok {
+		if prior != c {
+			return ErrConflict
+		}
+		return nil
+	}
+	op, ok := s.operations[c.OperationID]
+	if !ok || op.State != "running" {
+		return ErrConflict
+	}
+	kind := "cancel_requested"
+	if permission {
+		pending, ok := s.permissions[c.RequestID]
+		if !ok || pending.OperationID != c.OperationID {
+			return ErrConflict
+		}
+		// ACP options are opaque IDs. Only choices actually offered may be selected.
+		var request struct {
+			Options []struct {
+				OptionID string `json:"optionId"`
+			} `json:"options"`
+		}
+		if err := json.Unmarshal(pending.Payload, &request); err != nil {
+			return ErrConflict
+		}
+		valid := false
+		for _, option := range request.Options {
+			if option.OptionID == c.OptionID {
+				valid = true
+			}
+		}
+		if !valid {
+			return ErrConflict
+		}
+		kind = "permission_resolved"
+	}
+	if err := s.record(Event{OperationID: c.OperationID, Kind: kind, RequestID: c.RequestID, Control: &c}); err != nil {
+		return ErrUnavailable
+	}
+	if !permission {
+		s.cancels[c.OperationID]()
+	}
+	return nil
+}
+
+type Turn struct {
+	s   *Reference
+	id  string
+	ctx context.Context
+}
+
+func (t *Turn) Emit(kind string, payload json.RawMessage) error {
+	if kind != "acp" {
+		return errors.New("only ACP payloads may be emitted")
+	}
+	t.s.mu.Lock()
+	defer t.s.mu.Unlock()
+	state := t.s.operations[t.id].State
+	if state != "running" && state != "cancelling" {
+		return ErrConflict
+	}
+	return t.s.record(Event{OperationID: t.id, Kind: kind, Payload: payload})
+}
+func (t *Turn) Output(text string) error {
+	t.s.mu.Lock()
+	defer t.s.mu.Unlock()
+	if err := t.ctx.Err(); err != nil {
+		return err
+	}
+	return t.s.record(Event{OperationID: t.id, Kind: "output", Text: text})
+}
+func (t *Turn) Permission(id string, payload json.RawMessage) (string, error) {
+	encoded, _ := json.Marshal([]string{t.id, id})
+	key := string(encoded)
+	t.s.mu.Lock()
+	if _, exists := t.s.permissions[key]; exists {
+		t.s.mu.Unlock()
+		return "", ErrConflict
+	}
+	if _, exists := t.s.decisions[key]; exists {
+		t.s.mu.Unlock()
+		return "", ErrConflict
+	}
+	err := t.ctx.Err()
+	if err == nil {
+		err = t.s.record(Event{OperationID: t.id, Kind: "permission_request", RequestID: key, Payload: payload})
+	}
+	t.s.mu.Unlock()
+	if err != nil {
+		return "", err
 	}
 	for {
-		s.mu.Lock()
-		batch := append([]Event(nil), s.events[cursor:]...)
-		changed := s.changed
-		s.mu.Unlock()
-		for _, event := range batch {
-			data, _ := json.Marshal(event)
-			if _, err := fmt.Fprintf(w, "id: %d\ndata: %s\n\n", event.Sequence, data); err != nil {
-				return
-			}
-			if err := controller.Flush(); err != nil {
-				return
-			}
-			cursor = event.Sequence
+		t.s.mu.Lock()
+		decision, ok := t.s.decisions[key]
+		changed := t.s.changed
+		t.s.mu.Unlock()
+		if ok {
+			return decision, nil
 		}
 		select {
-		case <-r.Context().Done():
-			return
-		case <-s.ctx.Done():
-			return
+		case <-t.ctx.Done():
+			return "", t.ctx.Err()
 		case <-changed:
 		}
 	}

--- a/server/experiments/agenttransport/reference.go
+++ b/server/experiments/agenttransport/reference.go
@@ -304,7 +304,7 @@ func (t *Turn) Output(text string) error {
 	}
 	return t.s.record(Event{OperationID: t.id, Kind: "output", Text: text})
 }
-func (t *Turn) Permission(id string, payload json.RawMessage) (string, error) {
+func (t *Turn) Permission(ctx context.Context, id string, payload json.RawMessage) (string, error) {
 	encoded, _ := json.Marshal([]string{t.id, id})
 	key := string(encoded)
 	t.s.mu.Lock()
@@ -316,7 +316,10 @@ func (t *Turn) Permission(id string, payload json.RawMessage) (string, error) {
 		t.s.mu.Unlock()
 		return "", ErrConflict
 	}
-	err := t.ctx.Err()
+	err := context.Cause(ctx)
+	if err == nil {
+		err = t.ctx.Err()
+	}
 	if err == nil {
 		err = t.s.record(Event{OperationID: t.id, Kind: "permission_request", RequestID: key, Payload: payload})
 	}
@@ -329,10 +332,15 @@ func (t *Turn) Permission(id string, payload json.RawMessage) (string, error) {
 		decision, ok := t.s.decisions[key]
 		changed := t.s.changed
 		t.s.mu.Unlock()
+		if err := context.Cause(ctx); err != nil {
+			return "", err
+		}
 		if ok {
 			return decision, nil
 		}
 		select {
+		case <-ctx.Done():
+			return "", context.Cause(ctx)
 		case <-t.ctx.Done():
 			return "", t.ctx.Err()
 		case <-changed:

--- a/server/experiments/agenttransport/reference.go
+++ b/server/experiments/agenttransport/reference.go
@@ -3,6 +3,7 @@
 package agenttransport
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,8 +12,8 @@ import (
 )
 
 type Command struct {
-	ID     string `json:"id"`
-	Prompt string `json:"prompt"`
+	ID     string          `json:"id"`
+	Prompt json.RawMessage `json:"prompt"`
 }
 type Control struct {
 	ID          string `json:"id"`
@@ -31,7 +32,7 @@ type Event struct {
 	RequestID   string          `json:"requestId,omitempty"`
 }
 type Runner interface {
-	Run(context.Context, string, *Turn) error
+	Run(context.Context, json.RawMessage, *Turn) error
 }
 type Operation struct {
 	Command Command `json:"command"`
@@ -185,16 +186,29 @@ var ErrUnavailable = errors.New("runtime unavailable")
 var ErrUncertain = errors.New("agent outcome uncertain")
 
 func (s *Reference) Submit(c Command) (Operation, error) {
+	if c.ID == "" {
+		return Operation{}, ErrInvalidCommand
+	}
+	prompt, err := normalizePrompt(c.Prompt)
+	if err != nil {
+		return Operation{}, err
+	}
+	c.Prompt = prompt
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed || s.fault != nil {
 		return Operation{}, ErrUnavailable
 	}
 	if op, ok := s.operations[c.ID]; ok {
-		if op.Command != c {
+		if !bytes.Equal(op.Command.Prompt, c.Prompt) {
 			return Operation{}, ErrConflict
 		}
-		return op, nil
+		return copyOperation(op), nil
+	}
+	if validator, ok := s.runner.(interface{ ValidatePrompt(json.RawMessage) error }); ok {
+		if err := validator.ValidatePrompt(c.Prompt); err != nil {
+			return Operation{}, err
+		}
 	}
 	for _, op := range s.operations {
 		if op.State == "running" || op.State == "cancelling" || op.State == "uncertain" {
@@ -210,7 +224,7 @@ func (s *Reference) Submit(c Command) (Operation, error) {
 	go func() {
 		defer s.workers.Done()
 		defer cancel()
-		err := s.runner.Run(ctx, c.Prompt, &Turn{s: s, id: c.ID, ctx: ctx})
+		err := s.runner.Run(ctx, append(json.RawMessage(nil), c.Prompt...), &Turn{s: s, id: c.ID, ctx: ctx})
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		state, text := "completed", ""
@@ -224,7 +238,7 @@ func (s *Reference) Submit(c Command) (Operation, error) {
 		_ = s.record(Event{OperationID: c.ID, Kind: state, Text: text})
 		delete(s.cancels, c.ID)
 	}()
-	return s.operations[c.ID], nil
+	return copyOperation(s.operations[c.ID]), nil
 }
 
 func (s *Reference) Control(c Control, permission bool) error {

--- a/server/experiments/agenttransport/reference.go
+++ b/server/experiments/agenttransport/reference.go
@@ -1,0 +1,180 @@
+// Package agenttransport contains an experimental reconnect contract, not a
+// production endpoint. State survives client disconnects, not process restarts.
+package agenttransport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+)
+
+type Command struct {
+	ID     string `json:"id"`
+	Prompt string `json:"prompt"`
+}
+
+type Event struct {
+	Sequence    int    `json:"sequence"`
+	OperationID string `json:"operationId"`
+	Kind        string `json:"kind"`
+	Text        string `json:"text,omitempty"`
+}
+
+// Runner executes one accepted prompt. Its context belongs to the runtime,
+// never to the HTTP request. Emit must finish before Run returns.
+type Runner interface {
+	Run(context.Context, string, func(string)) error
+}
+
+type operation struct {
+	command Command
+	state   string
+}
+
+// Reference is a single-session, in-memory transport used to test the contract.
+// It deliberately does not implement ACP or authenticate network callers.
+type Reference struct {
+	ctx        context.Context
+	cancel     context.CancelFunc
+	runner     Runner
+	mu         sync.Mutex
+	operations map[string]operation
+	events     []Event
+	changed    chan struct{}
+	workers    sync.WaitGroup
+	closed     bool
+}
+
+func NewReference(runner Runner) *Reference {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Reference{ctx: ctx, cancel: cancel, runner: runner, operations: make(map[string]operation), changed: make(chan struct{})}
+}
+
+func (s *Reference) Close() {
+	s.mu.Lock()
+	s.closed = true
+	s.cancel()
+	s.mu.Unlock()
+	s.workers.Wait()
+}
+
+func (s *Reference) appendLocked(id, kind, text string) {
+	s.events = append(s.events, Event{len(s.events) + 1, id, kind, text})
+	close(s.changed)
+	s.changed = make(chan struct{})
+}
+
+func (s *Reference) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/commands":
+		s.submit(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/events":
+		s.stream(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Reference) submit(w http.ResponseWriter, r *http.Request) {
+	var c Command
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10))
+	if err := decoder.Decode(&c); err != nil || c.ID == "" || c.Prompt == "" {
+		http.Error(w, "invalid command", http.StatusBadRequest)
+		return
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		http.Error(w, "expected one command", http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		http.Error(w, "runtime closed", http.StatusServiceUnavailable)
+		return
+	}
+	if existing, ok := s.operations[c.ID]; ok {
+		if existing.command != c {
+			http.Error(w, "operation ID reused with different payload", http.StatusConflict)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": c.ID, "state": existing.state})
+		return
+	}
+	s.operations[c.ID] = operation{c, "running"}
+	s.appendLocked(c.ID, "accepted", "")
+	s.workers.Add(1)
+	go func() {
+		defer s.workers.Done()
+		err := s.runner.Run(s.ctx, c.Prompt, func(text string) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			s.appendLocked(c.ID, "output", text)
+		})
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		state, text := "completed", ""
+		if err != nil {
+			state, text = "failed", err.Error()
+		}
+		s.operations[c.ID] = operation{c, state}
+		s.appendLocked(c.ID, state, text)
+	}()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]string{"id": c.ID, "state": "running"})
+}
+
+func (s *Reference) stream(w http.ResponseWriter, r *http.Request) {
+	cursor := 0
+	if value := r.Header.Get("Last-Event-ID"); value != "" {
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 0 {
+			http.Error(w, "invalid cursor", http.StatusBadRequest)
+			return
+		}
+		cursor = n
+	}
+	s.mu.Lock()
+	future := cursor > len(s.events)
+	s.mu.Unlock()
+	if future {
+		http.Error(w, "cursor ahead of session", http.StatusConflict)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	controller := http.NewResponseController(w)
+	if err := controller.Flush(); err != nil {
+		return
+	}
+	for {
+		s.mu.Lock()
+		batch := append([]Event(nil), s.events[cursor:]...)
+		changed := s.changed
+		s.mu.Unlock()
+		for _, event := range batch {
+			data, _ := json.Marshal(event)
+			if _, err := fmt.Fprintf(w, "id: %d\ndata: %s\n\n", event.Sequence, data); err != nil {
+				return
+			}
+			if err := controller.Flush(); err != nil {
+				return
+			}
+			cursor = event.Sequence
+		}
+		select {
+		case <-r.Context().Done():
+			return
+		case <-s.ctx.Done():
+			return
+		case <-changed:
+		}
+	}
+}

--- a/server/experiments/agenttransport/reference.go
+++ b/server/experiments/agenttransport/reference.go
@@ -92,12 +92,13 @@ func (s *Reference) submit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.closed {
+		s.mu.Unlock()
 		http.Error(w, "runtime closed", http.StatusServiceUnavailable)
 		return
 	}
 	if existing, ok := s.operations[c.ID]; ok {
+		s.mu.Unlock()
 		if existing.command != c {
 			http.Error(w, "operation ID reused with different payload", http.StatusConflict)
 			return
@@ -126,6 +127,7 @@ func (s *Reference) submit(w http.ResponseWriter, r *http.Request) {
 		s.operations[c.ID] = operation{c, state}
 		s.appendLocked(c.ID, state, text)
 	}()
+	s.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{"id": c.ID, "state": "running"})

--- a/server/experiments/agenttransport/store.go
+++ b/server/experiments/agenttransport/store.go
@@ -1,0 +1,126 @@
+package agenttransport
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+)
+
+// Store must durably append an event before returning success. One runtime owns
+// a store; replay and appends are serialized by the runtime.
+type Store interface {
+	Load() ([]Event, error)
+	Append(Event) error
+	Close() error
+}
+
+type MemoryStore struct{ events []Event }
+
+func (s *MemoryStore) Load() ([]Event, error) { return append([]Event(nil), s.events...), nil }
+func (s *MemoryStore) Append(e Event) error   { s.events = append(s.events, e); return nil }
+func (s *MemoryStore) Close() error           { return nil }
+
+// FileStore is an append-only journal for the experiment. A file lock excludes
+// concurrent owners. A failed write poisons the handle until it is reopened.
+type FileStore struct {
+	file     *os.File
+	failed   error
+	once     sync.Once
+	closeErr error
+}
+
+func OpenFileStore(path string) (*FileStore, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("journal already owned: %w", err)
+	}
+	s := &FileStore{file: file}
+	if _, err = s.Load(); err != nil {
+		s.Close()
+		return nil, err
+	}
+	// Persist file creation before accepting commands.
+	dir, err := os.OpenFile(filepath.Dir(path), os.O_RDONLY, 0)
+	if err != nil {
+		s.Close()
+		return nil, err
+	}
+	err = dir.Sync()
+	dir.Close()
+	if err != nil {
+		s.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *FileStore) Load() ([]Event, error) {
+	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(s.file)
+	if err != nil {
+		return nil, err
+	}
+	end := bytes.LastIndexByte(data, '\n') + 1
+	// An incomplete final record could not have been acknowledged: append writes
+	// a newline before syncing. Complete but corrupt records fail closed.
+	if end != len(data) {
+		if err := s.file.Truncate(int64(end)); err != nil {
+			return nil, err
+		}
+		if err := s.file.Sync(); err != nil {
+			return nil, err
+		}
+	}
+	events := make([]Event, 0)
+	for _, line := range bytes.Split(data[:end], []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var event Event
+		if err := json.Unmarshal(line, &event); err != nil {
+			return nil, fmt.Errorf("invalid journal record: %w", err)
+		}
+		if event.Sequence != len(events)+1 {
+			return nil, errors.New("non-contiguous journal sequence")
+		}
+		events = append(events, event)
+	}
+	_, err = s.file.Seek(0, io.SeekEnd)
+	return events, err
+}
+
+func (s *FileStore) Append(e Event) error {
+	if s.failed != nil {
+		return s.failed
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	n, err := s.file.Write(data)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
+	}
+	if err == nil {
+		err = s.file.Sync()
+	}
+	s.failed = err
+	return err
+}
+func (s *FileStore) Close() error {
+	s.once.Do(func() { s.closeErr = s.file.Close() })
+	return s.closeErr
+}


### PR DESCRIPTION
## Summary
- Add an isolated POST/SSE session-service experiment with operation/control deduplication, durable event journaling, replay, permissions, and cancellation. No production routes or image dependencies change.
- Treat interrupted work as uncertain after agent loss or service restart, preventing automatic redispatch and fencing new commands.
- Add a reusable ACP v1 stdio test driver, counted MCP checkpoint tool, deterministic subprocess peer, and opt-in real-harness suite with configuration/evidence instructions.
- Require explicit permission configuration; skipped harness tests are not support claims. Forced process termination does not pass native cancellation acceptance.
- Preserve ACP content blocks and prompt responses/errors with bounded admission, capability checks, and end-to-end content fidelity tests. Document the proposed ACP-first API, reset/resume, and configuration scopes; these production lifecycle operations are not implemented.

## Validation
- Passed: go test -race -count=100 ./experiments/agenttransport/... on the latest commit.
- Mutation checks fail as expected when content is flattened or large metadata integers are rounded. Earlier mutation checks also detected dropped cancellation updates and misclassified interrupted recovery.
- Passed: full non-e2e Go suite with the race detector.
- Passed: go vet ./experiments/agenttransport/...
- Actual HTTP/TCP disconnects, lost acknowledgements, subprocess kills (including during permission waits), journal recovery, permission retries, and cancellation are exercised.
- Latest commit c7e3e46: all CI checks pass, including server-unit tests, image e2e tests, and Bugbot (no issues found).
- Real harnesses and local image e2e tests have not been run. The real-harness suite explicitly reports NOT VALIDATED when configuration is absent.

## Scope and limits
This is an experiment and acceptance-test foundation, not a production endpoint or finalized ACP HTTP implementation. The journal/replay index remains unbounded; authentication, tenant isolation, retention, reconciliation, remote proxy behavior, and suspend/restore validation remain out of scope. Local process-kill recovery is not a power-loss or host-loss guarantee. No agent installation or real-provider authentication is performed by default. Experimental prompts now require ACP content arrays rather than strings; legacy journals are not migrated. Harness fan-out is paused pending alignment on the proposed lifecycle/configuration contract.

