### PR TITLE
Fix replay audio timing reliability

### DIFF
--- a/.github/workflows/server-test.yaml
+++ b/.github/workflows/server-test.yaml
@@ -133,3 +133,13 @@ jobs:
         env:
           E2E_CHROMIUM_HEADFUL_IMAGE: onkernel/chromium-headful:${{ steps.vars.outputs.short_sha }}
           E2E_CHROMIUM_HEADLESS_IMAGE: onkernel/chromium-headless:${{ steps.vars.outputs.short_sha }}
+          RECORDING_AUDIO_OUTPUT_PATH: ${{ runner.temp }}/replay-audio/recording.mp4
+
+      - name: Upload replay audio diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: replay-audio-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/replay-audio/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/server-test.yaml
+++ b/.github/workflows/server-test.yaml
@@ -51,6 +51,9 @@ jobs:
           git diff --exit-code -- lib/events/category_gen.go
         working-directory: server
 
+      - name: Install recording regression dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Run server unit tests
         run: make test-unit
         working-directory: server

--- a/server/Makefile
+++ b/server/Makefile
@@ -46,7 +46,7 @@ test-e2e:
 	@echo ""
 	@echo "=== Running e2e tests (this may take a few minutes) ==="
 	@echo ""
-	go test -v -race -timeout 120m ./e2e/
+	go test -v -race -count=1 -timeout 120m ./e2e/
 
 clean:
 	@rm -rf $(BIN_DIR)

--- a/server/e2e/e2e_recording_audio_test.go
+++ b/server/e2e/e2e_recording_audio_test.go
@@ -41,6 +41,14 @@ func TestReplayRecordingIncludesAudioTrack(t *testing.T) {
 	require.NoError(t, c.WaitReady(ctx), "api not ready")
 	require.NoError(t, c.WaitDevTools(ctx), "devtools not ready")
 
+	// WIDTH/HEIGHT configure Xvfb, not headful Xorg. Apply the intended size
+	// through the API instead of recording the dummy display's 4K default.
+	initialWidth, initialHeight, err := getXRootResolution(ctx, c)
+	require.NoError(t, err)
+	t.Logf("[replay-audio] initial display=%dx%d", initialWidth, initialHeight)
+	patchDisplayExpectingOK(t, ctx, c, 1280, 720, 60)
+	waitForXRootResolution(t, ctx, c, 1280, 720, 15*time.Second)
+
 	// Verify the browser sees a real sound card over pure CDP/websocket. Chromium
 	// excludes PulseAudio monitor sources from enumerateDevices(), so the
 	// recorder's capture sink alone is invisible as an input. The standalone

--- a/server/e2e/e2e_recording_audio_test.go
+++ b/server/e2e/e2e_recording_audio_test.go
@@ -151,6 +151,10 @@ func TestReplayRecordingZombocomArchiveAudio(t *testing.T) {
 func recordReplayAudio(t *testing.T, ctx context.Context, c *TestContainer, playwrightCode string, outputPath string, minPeakLevel float64) {
 	t.Helper()
 
+	if outputPath != "" {
+		defer captureReplayAudioDiagnostics(t, c, outputPath)
+	}
+
 	client, err := c.APIClient()
 	require.NoError(t, err, "failed to create API client")
 
@@ -160,6 +164,7 @@ func recordReplayAudio(t *testing.T, ctx context.Context, c *TestContainer, play
 	maxDuration := 120
 	maxFileSize := 100
 	recordAudio := true
+	startTime := time.Now()
 	startResp, err := client.StartRecordingWithResponse(ctx, instanceoapi.StartRecordingJSONRequestBody{
 		MaxDurationInSeconds: &maxDuration,
 		MaxFileSizeInMB:      &maxFileSize,
@@ -168,6 +173,7 @@ func recordReplayAudio(t *testing.T, ctx context.Context, c *TestContainer, play
 	require.NoError(t, err, "POST /recording/start failed")
 	require.Equal(t, http.StatusCreated, startResp.StatusCode(), "unexpected start status: %s body=%s", startResp.Status(), string(startResp.Body))
 
+	t.Logf("[replay-audio] recording start took %s", time.Since(startTime))
 	stopped := false
 	defer func() {
 		if !stopped {
@@ -176,9 +182,11 @@ func recordReplayAudio(t *testing.T, ctx context.Context, c *TestContainer, play
 		}
 	}()
 
+	playwrightStart := time.Now()
 	runResp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{
 		Code: playwrightCode,
 	})
+	t.Logf("[replay-audio] playwright took %s", time.Since(playwrightStart))
 	require.NoError(t, err, "playwright request failed")
 	require.Equal(t, http.StatusOK, runResp.StatusCode(), "unexpected playwright status: %s body=%s", runResp.Status(), string(runResp.Body))
 	require.NotNil(t, runResp.JSON200, "expected playwright JSON response")
@@ -186,7 +194,9 @@ func recordReplayAudio(t *testing.T, ctx context.Context, c *TestContainer, play
 		t.Fatalf("playwright execution failed: error=%s stderr=%s result=%#v", stringValue(runResp.JSON200.Error), stringValue(runResp.JSON200.Stderr), runResp.JSON200.Result)
 	}
 
+	stopTime := time.Now()
 	stopResp, err := client.StopRecordingWithResponse(ctx, instanceoapi.StopRecordingJSONRequestBody{})
+	t.Logf("[replay-audio] recording stop took %s; elapsed %s", time.Since(stopTime), time.Since(startTime))
 	stopped = true
 	require.NoError(t, err, "POST /recording/stop failed")
 	require.Equal(t, http.StatusOK, stopResp.StatusCode(), "unexpected stop status: %s body=%s", stopResp.Status(), string(stopResp.Body))
@@ -205,6 +215,7 @@ func recordReplayAudio(t *testing.T, ctx context.Context, c *TestContainer, play
 	require.True(t, mp4HasAudioTrack(downloadResp.Body), "downloaded recording does not contain an audio track")
 	require.Greater(t, mp4AudioPeakLevel(t, ctx, c, recordingPath), minPeakLevel, "downloaded recording audio track is silent")
 	formatDuration, audioDuration := mp4Durations(t, ctx, c, recordingPath)
+	t.Logf("[replay-audio] format_duration=%.6f audio_duration=%.6f gap=%.6f", formatDuration, audioDuration, formatDuration-audioDuration)
 	require.GreaterOrEqual(t, audioDuration, formatDuration-2, "downloaded recording audio track ends before the recording does")
 }
 

--- a/server/e2e/recording_audio_diagnostics_test.go
+++ b/server/e2e/recording_audio_diagnostics_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,8 +19,20 @@ func captureReplayAudioDiagnostics(t *testing.T, c *TestContainer, outputPath st
 		t.Logf("audio diagnostics: %v", err)
 		return
 	}
+	// A failed Playwright request still leaves a useful recording after cleanup.
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		client, err := c.APIClient()
+		if err == nil {
+			response, err := client.DownloadRecordingWithResponse(ctx, nil)
+			if err == nil && response.StatusCode() == http.StatusOK {
+				if err := os.WriteFile(outputPath, response.Body, 0o644); err != nil {
+					t.Logf("audio diagnostics recording: %v", err)
+				}
+			}
+		}
+	}
 	commands := map[string][]string{
-		"probe.json":   {"ffprobe", "-v", "error", "-show_format", "-show_streams", "-show_packets", "-of", "json", "/tmp/e2e-recording-audio.mp4"},
+		"probe.json":   {"ffprobe", "-v", "error", "-show_format", "-show_streams", "-show_packets", "-of", "json", "/recordings/default.mp4"},
 		"services.log": {"sh", "-c", "for f in /var/log/supervisord/kernel-images-api /var/log/supervisord/pulseaudio /var/log/supervisord.log; do echo ==== $f; cat $f; done"},
 		"pulse.log":    {"sh", "-c", "PULSE_SERVER=unix:/tmp/pulse/native pactl list sinks; PULSE_SERVER=unix:/tmp/pulse/native pactl list source-outputs"},
 	}

--- a/server/e2e/recording_audio_diagnostics_test.go
+++ b/server/e2e/recording_audio_diagnostics_test.go
@@ -1,0 +1,35 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Capture only the isolated audio fixture's services, never environment variables
+// or browser storage. Run before the test container is removed, including on failure.
+func captureReplayAudioDiagnostics(t *testing.T, c *TestContainer, outputPath string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		t.Logf("audio diagnostics: %v", err)
+		return
+	}
+	commands := map[string][]string{
+		"probe.json":   {"ffprobe", "-v", "error", "-show_format", "-show_streams", "-show_packets", "-of", "json", "/tmp/e2e-recording-audio.mp4"},
+		"services.log": {"sh", "-c", "for f in /var/log/supervisord/kernel-images-api /var/log/supervisord/pulseaudio /var/log/supervisord.log; do echo ==== $f; cat $f; done"},
+		"pulse.log":    {"sh", "-c", "PULSE_SERVER=unix:/tmp/pulse/native pactl list sinks; PULSE_SERVER=unix:/tmp/pulse/native pactl list source-outputs"},
+	}
+	for suffix, command := range commands {
+		code, out, err := c.Exec(ctx, command)
+		if err != nil || code != 0 {
+			t.Logf("audio diagnostics %s: exit=%d err=%v", suffix, code, err)
+		}
+		if err := os.WriteFile(outputPath+"."+suffix, []byte(out), 0o644); err != nil {
+			t.Logf("audio diagnostics: %v", err)
+		}
+	}
+}

--- a/server/lib/recorder/audio_integration_test.go
+++ b/server/lib/recorder/audio_integration_test.go
@@ -1,0 +1,102 @@
+package recorder
+
+import (
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFFmpegAudioPreservesInputStartOffset(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("separate PulseAudio input is Linux-only")
+	}
+	for _, binary := range []string{"ffmpeg", "ffprobe"} {
+		if _, err := exec.LookPath(binary); err != nil {
+			t.Skipf("%s required: %v", binary, err)
+		}
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audio.mp4")
+	params := defaultParams(dir)
+	audio := true
+	params.RecordAudio = &audio
+	args, err := ffmpegArgs(params, path)
+	require.NoError(t, err)
+
+	// Model live devices opened three seconds apart on the same clock. Both
+	// finish at timestamp 16, so their final output packets must still coincide.
+	// Replace only capture devices; retain the production sync/encode/mux flags.
+	fixtureArgs := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "-framerate":
+			i++
+		case args[i] == "-f" && (args[i+1] == "x11grab" || args[i+1] == "pulse"):
+			fixtureArgs = append(fixtureArgs, "-f", "lavfi")
+			i++
+		case args[i] == "-i":
+			input := "testsrc2=size=320x240:rate=10:duration=6,setpts=PTS+10/TB"
+			if args[i+1] == "KernelOutput.monitor" {
+				input = "sine=frequency=440:sample_rate=48000:duration=3,asetpts=PTS+13/TB"
+			}
+			fixtureArgs = append(fixtureArgs, "-i", input)
+			i++
+		default:
+			fixtureArgs = append(fixtureArgs, args[i])
+		}
+	}
+	out, err := exec.CommandContext(t.Context(), "ffmpeg", fixtureArgs...).CombinedOutput()
+	require.NoError(t, err, "%s", out)
+	for _, name := range []string{"fragmented", "finalized"} {
+		t.Run(name, func(t *testing.T) {
+			if name == "finalized" {
+				finalized := filepath.Join(dir, "finalized.mp4")
+				out, err := exec.CommandContext(t.Context(), "ffmpeg", remuxArgs(path, finalized, "")...).CombinedOutput()
+				require.NoError(t, err, "%s", out)
+				path = finalized
+			}
+			out, err := exec.CommandContext(t.Context(), "ffprobe", "-v", "error", "-show_packets", "-of", "json", path).Output()
+			require.NoError(t, err)
+			var probe struct {
+				Packets []struct {
+					CodecType string `json:"codec_type"`
+					PTS       string `json:"pts_time"`
+					Duration  string `json:"duration_time"`
+				} `json:"packets"`
+			}
+			require.NoError(t, json.Unmarshal(out, &probe))
+			var videoEnd, audioEnd float64
+			audioPTS := make([]float64, 0)
+			for _, p := range probe.Packets {
+				pts, err := strconv.ParseFloat(p.PTS, 64)
+				require.NoError(t, err)
+				var duration float64
+				if p.Duration != "" {
+					duration, err = strconv.ParseFloat(p.Duration, 64)
+					require.NoError(t, err)
+				}
+				if p.CodecType == "video" {
+					videoEnd = pts + duration
+				} else if p.CodecType == "audio" {
+					audioEnd = pts + duration
+					audioPTS = append(audioPTS, pts)
+				}
+			}
+			t.Logf("video_end=%.6f audio_end=%.6f", videoEnd, audioEnd)
+			require.InDelta(t, videoEnd, audioEnd, 0.1, "independently zeroing input timestamps moves audio three seconds early")
+			// empty_moov starts the first packet at zero. Subsequent packets must
+			// preserve the device offset, without padding the gap with silent samples.
+			require.Greater(t, len(audioPTS), 1)
+			require.InDelta(t, 3, audioPTS[1], 0.03)
+			pcm, err := exec.CommandContext(t.Context(), "ffmpeg", "-v", "error", "-i", path,
+				"-map", "0:a:0", "-f", "s16le", "-ac", "2", "-ar", "48000", "-").Output()
+			require.NoError(t, err)
+			require.InDelta(t, 3, float64(len(pcm))/(48000*2*2), 0.05, "sync must not add silent samples")
+		})
+	}
+}

--- a/server/lib/recorder/ffmpeg.go
+++ b/server/lib/recorder/ffmpeg.go
@@ -748,10 +748,8 @@ func ffmpegArgs(params FFmpegRecordingParams, outputPath string) ([]string, erro
 		"-pix_fmt", "yuv420p", // Web-standard pixel format
 	}...)
 
-	// Timestamp handling for reliable playback. Single-input video-only capture
-	// overwrites x11grab's timestamps with wall-clock time for stable playback.
-	// With audio we must not: it would stamp the separate video and audio inputs
-	// independently and desync them, so we keep their input PTS instead.
+	// Keep the legacy timestamp options for video-only capture. Audio capture
+	// synchronizes the two device clocks with -isync on the PulseAudio input.
 	if !recordAudio {
 		args = append(args, "-use_wallclock_as_timestamps", "1")
 	}
@@ -783,6 +781,10 @@ func ffmpegArgs(params FFmpegRecordingParams, outputPath string) ([]string, erro
 func audioInputArgs(params FFmpegRecordingParams) []string {
 	return []string{
 		"-thread_queue_size", "512",
+		// Both devices use wall-clock timestamps, but open at different times.
+		// Without -isync, ffmpeg subtracts each input's start independently,
+		// shifting the later-opened audio earlier by the device startup gap.
+		"-isync", "0",
 		"-f", "pulse",
 		"-i", params.audioSource(),
 	}

--- a/server/runtime/playwright-daemon.test.ts
+++ b/server/runtime/playwright-daemon.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createConnection } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+test('socket readiness does not wait for cold browser-engine imports', { timeout: 10000 }, async t => {
+  const dir = await mkdtemp(join(tmpdir(), 'playwright-startup-'));
+  const socketPath = join(dir, 'daemon.sock');
+  const started = join(dir, 'import-started');
+  const release = join(dir, 'release-import');
+  const loader = join(dir, 'loader.mjs');
+  // Hold package evaluation until released, rather than depending on CPU load
+  // or the speed of installed Playwright packages to reproduce cold startup.
+  const engine = `
+    import { existsSync, writeFileSync } from 'node:fs';
+    import { setTimeout } from 'node:timers/promises';
+    writeFileSync(${JSON.stringify(started)}, '');
+    while (!existsSync(${JSON.stringify(release)})) await setTimeout(20);
+    export const chromium = { connectOverCDP: async () => ({
+      on() {}, isConnected() { return true; }, async close() {}
+    }) };
+    export const transform = async code => ({ code });
+    export const Browser = null, CDPSession = null, Page = null;
+  `;
+  await writeFile(loader, `
+    export async function resolve(specifier, context, nextResolve) {
+      if (['playwright-core', 'patchright', 'esbuild'].includes(specifier)) {
+        return { url: 'data:text/javascript,' + encodeURIComponent(${JSON.stringify(engine)}), shortCircuit: true };
+      }
+      if (['./page-target-id-cache', './webmcp'].includes(specifier)) specifier += '.ts';
+      return nextResolve(specifier, context);
+    }
+  `);
+  const child = spawn(process.execPath, [
+    '--experimental-loader', pathToFileURL(loader).href,
+    new URL('./playwright-daemon.ts', import.meta.url).pathname,
+  ], { env: { ...process.env, PLAYWRIGHT_DAEMON_SOCKET: socketPath }, stdio: ['ignore', 'ignore', 'pipe'] });
+  let stderr = '';
+  child.stderr.on('data', chunk => { stderr += chunk; });
+  const exited = once(child, 'exit');
+  t.after(async () => {
+    child.kill('SIGKILL');
+    await exited;
+    await rm(dir, { recursive: true, force: true });
+  });
+  const deadline = performance.now() + 4000;
+  while ((!existsSync(started) || !existsSync(socketPath)) && performance.now() < deadline && child.exitCode === null) {
+    await setTimeout(20);
+  }
+  assert.ok(existsSync(started), `engine import was not exercised: ${stderr}`);
+  assert.ok(existsSync(socketPath), `socket blocked by engine initialization: ${stderr}`);
+  const socket = createConnection(socketPath);
+  try {
+    await once(socket, 'connect');
+  } finally {
+    socket.destroy();
+  }
+  await writeFile(release, '');
+  const connectedDeadline = performance.now() + 2000;
+  while (!stderr.includes('CDP connection established') && performance.now() < connectedDeadline) {
+    await setTimeout(20);
+  }
+  assert.match(stderr, /CDP connection established/);
+});

--- a/server/runtime/playwright-daemon.ts
+++ b/server/runtime/playwright-daemon.ts
@@ -11,9 +11,7 @@
 
 import { createServer, Socket } from 'net';
 import { unlinkSync, existsSync } from 'fs';
-import { transform } from 'esbuild';
-import { chromium as chromiumPW, Browser, CDPSession, Page } from 'playwright-core';
-import { chromium as chromiumPR } from 'patchright';
+import type { Browser, CDPSession, Page } from 'playwright-core';
 
 import { PageTargetIdCache } from './page-target-id-cache';
 import { createWebMCPClient } from './webmcp';
@@ -71,6 +69,7 @@ async function transformCode(code: string): Promise<string> {
   // Wrap in async function so top-level await/return are valid for esbuild
   const wrapped = `async function __userCode__() {\n${code}\n}`;
 
+  const { transform } = await import('esbuild');
   const result = await transform(wrapped, {
     loader: 'ts',
     target: 'es2022',
@@ -117,7 +116,11 @@ async function ensureBrowserConnection(): Promise<Browser> {
 
   connecting = true;
   try {
-    const chromium = USE_PATCHRIGHT ? chromiumPR : chromiumPW;
+    // Load the engine after socket binding, outside the API's short
+    // socket-ready deadline. Only initialize the selected engine.
+    const { chromium } = USE_PATCHRIGHT
+      ? await import('patchright')
+      : await import('playwright-core');
 
     if (browser) {
       try {


### PR DESCRIPTION
## Summary

- Synchronize the PulseAudio input to x11grab with `-isync 0`. Both use wall-clock timestamps, but ffmpeg otherwise subtracts each input start independently, pulling later-opened audio forward and ending it early in the replay timeline.
- Bind the Playwright daemon socket before importing the selected browser engine; import esbuild only when transforming code. Previously all three packages initialized before listening. Keep the existing 5-second socket deadline.
- Explicitly apply and verify the fixture's intended 1280×720 display through the API. `WIDTH`/`HEIGHT` alone do not configure headful Xorg; CI was recording its 3840×2160 fallback instead.
- Retain the real-browser audio MP4, packet/stream timestamps and isolated service logs in e2e CI. Log measured durations and lifecycle timings; run the normal parallel e2e suite uncached.

The existing 2-second audio-duration assertion, audible-tone check, recording-before-first-Playwright ordering and e2e concurrency are unchanged. No audio padding, test retries or production deployment.

## Regression evidence

- New ffmpeg regression models devices opening at timestamps 10 and 13 and both finishing at 16, retaining production encode/mux arguments. Pre-fix: video ends at 6.021387s, audio at 3.029333s. Fixed: 6.000000s / 6.008000s, before and after remux. Decoding still yields only about 3 seconds of audio, not padded silence.
- New daemon regression holds dependency evaluation until explicitly released. Pre-fix the socket remains absent; fixed it accepts connections while the engine import is blocked, then connects after release. This proves the startup dependency, not CPU contention in historical CI failures.

## Validation

- Local `make test-unit` (vet and Go race tests) and `make test-runtime` pass. An earlier baseline unit run hit an unrelated devtoolsproxy Chromium TempDir cleanup race; the complete rerun passed.
- Full local parallel real-container suite passes with both updated headful/headless images and verified 1280×720 capture: video 10.100000s, audio 9.971750s, gap 0.128250s, no non-monotonic DTS warnings.
- The first candidate passed three independent CI jobs, but one had a 1.795333s gap, 28 non-monotonic audio DTS warnings and ffmpeg final speed 0.858x while encoding unintended 4K video. Validation was stopped proactively rather than accepting a near-threshold result. Correcting fixture setup reduces raw frame bandwidth from 2,654,208 to 294,912 kbit/s (9×), without changing suite parallelism or production recording settings. The local corrected full-suite run sustained 1.04x with no DTS warnings.
- Final commit `8897c2a881ce2a08a5faac4554e305399d5f972e` passed ten consecutive independent full parallel e2e CI jobs. All normal CI checks and latest-commit BugBot are green; BugBot reported no issues. No code changed during validation.

## Ten-run CI evidence

Workflow `server-test.yaml`, run **34002849643**, attempts **1–10**. Each is a distinct job execution of the full normal parallel suite with `-race -count=1`; the target ran exactly once without skips or retries. Source SHA `8897c2a881ce2a08a5faac4554e305399d5f972e`; tested merge SHA `cd4a15bdaa7dcbbb649e6ca4c8fb06e3673b26b2` throughout.

| Attempt | Independent e2e job | Video / format (s) | Audio (s) | Outcome |
| --- | --- | ---: | ---: | --- |
| 1 | [101404737767](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101404737767) | 9.400000 | 9.269750 | PASS |
| 2 | [101405310678](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101405310678) | 8.900000 | 8.830000 | PASS |
| 3 | [101405973470](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101405973470) | 9.800000 | 9.664396 | PASS |
| 4 | [101406546784](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101406546784) | 9.600000 | 9.526396 | PASS |
| 5 | [101407211513](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101407211513) | 9.400000 | 9.185375 | PASS |
| 6 | [101407785465](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101407785465) | 9.600000 | 9.559938 | PASS |
| 7 | [101408374366](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101408374366) | 10.500000 | 10.433687 | PASS |
| 8 | [101408938930](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101408938930) | 9.900000 | 9.759292 | PASS |
| 9 | [101409567192](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101409567192) | 9.100000 | 8.994167 | PASS |
| 10 | [101410190324](https://github.com/kernel/kernel-images/actions/runs/34002849643/job/101410190324) | 9.300000 | 9.162354 | PASS |

Largest gap: **0.214625s** against the unchanged **2s** assertion. Each run has a `replay-audio-34002849643-<attempt>` artifact containing the MP4, stream/packet probe and service logs. Every video is verified as 1280×720. Minor Pulse timestamp warnings remain visible in those logs; no universal overloaded-4K recording guarantee is claimed.
