### PR TITLE
Test declarative WebMCP discovery and invocation

### DIFF
--- a/server/e2e/e2e_playwright_test.go
+++ b/server/e2e/e2e_playwright_test.go
@@ -254,6 +254,10 @@ func TestPlaywrightExecuteAPI(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resultBytes, &crossContextResult))
 	require.Equal(t, "data:text/html,second-context", crossContextResult.URL, "expected active-page resolution to select the foreground page, not the newer fallback page")
 	require.ElementsMatch(t, []string{"data:text/html,second-context", "about:blank"}, crossContextResult.ContextPageURLs, "expected the selected page to belong to the second context")
+
+	t.Run("WebMCPDeclarative", func(t *testing.T) {
+		testWebMCPDeclarative(t, ctx, client)
+	})
 }
 
 func TestPlaywrightExecuteTimeoutReturnsPromptlyAndRecovers(t *testing.T) {

--- a/server/e2e/e2e_webmcp_test.go
+++ b/server/e2e/e2e_webmcp_test.go
@@ -1,0 +1,180 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	instanceoapi "github.com/kernel/kernel-images/server/lib/oapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebMCPDeclarative(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	c := NewTestContainer(t, headlessImage)
+	require.NoError(t, c.Start(ctx, ContainerConfig{}))
+	defer c.Stop(ctx)
+	require.NoError(t, c.WaitReady(ctx))
+
+	client, err := c.APIClient()
+	require.NoError(t, err)
+
+	// Like the audio fixture, use file:// inside the instance to provide a secure
+	// context without external URLs or a Docker-only host-loopback bridge.
+	for _, name := range []string{"reservation.html", "embedded.html"} {
+		fixture, err := os.ReadFile("testdata/webmcp/" + name)
+		require.NoError(t, err)
+		rsp, err := client.WriteFileWithBodyWithResponse(ctx,
+			&instanceoapi.WriteFileParams{Path: "/tmp/" + name}, "text/html", bytes.NewReader(fixture))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, rsp.StatusCode(), "%s", rsp.Body)
+	}
+
+	for _, test := range []struct {
+		name  string
+		file  string
+		title string
+		frame bool
+	}{
+		{name: "top_level", file: "reservation.html", title: "Declarative reservation"},
+		{name: "embedded", file: "embedded.html", title: "Embedded declarative reservation", frame: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pageURL := "file:///tmp/" + test.file
+			var secureContext bool
+			executeWebMCPPlaywright(t, ctx, client, fmt.Sprintf(`
+				await page.goto(%q, { waitUntil: 'load' });
+				const frame = page.frames().find(frame => frame.url() === 'file:///tmp/reservation.html');
+				await frame.locator('form[toolname="reserve_table"]').waitFor();
+				return frame.evaluate(() => isSecureContext);
+			`, pageURL), &secureContext)
+			require.True(t, secureContext)
+
+			var tool instanceoapi.WebMCPTool
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				rsp, err := client.GetWebMCPToolsWithResponse(ctx)
+				if !assert.NoError(collect, err) {
+					return
+				}
+				if !assert.Equal(collect, http.StatusOK, rsp.StatusCode(), "%s", rsp.Body) || !assert.NotNil(collect, rsp.JSON200) {
+					return
+				}
+				for _, candidate := range rsp.JSON200.Tools {
+					if candidate.Name == "reserve_table" && candidate.Source.PageUrl == pageURL {
+						tool = candidate
+						return
+					}
+				}
+				assert.Fail(collect, "declarative tool not discovered", "%s", rsp.Body)
+			}, 10*time.Second, 200*time.Millisecond)
+			toolJSON, err := json.Marshal(tool)
+			require.NoError(t, err)
+			t.Logf("GET /webmcp/tools: %s", toolJSON)
+			require.NotEmpty(t, tool.ToolRef)
+			require.Equal(t, "Reserve a table with guest details and seating preferences.", tool.Description)
+			require.Equal(t, "object", tool.InputSchema["type"])
+			properties, ok := tool.InputSchema["properties"].(map[string]any)
+			require.True(t, ok, "schema properties: %#v", tool.InputSchema)
+			require.Len(t, properties, 4)
+			for _, field := range []struct {
+				name, kind, description string
+			}{
+				{"name", "string", "Name for the reservation"},
+				{"date", "string", "Date of the reservation"},
+				{"party_size", "number", "Number of guests"},
+				{"seating", "string", "Preferred seating area"},
+			} {
+				property, ok := properties[field.name].(map[string]any)
+				require.True(t, ok, "missing property %s", field.name)
+				require.Equal(t, field.kind, property["type"], field.name)
+				description, ok := property["description"].(string)
+				require.True(t, ok, "missing description for %s", field.name)
+				// Chromium appends a format hint to date descriptions.
+				require.True(t, strings.HasPrefix(description, field.description), "%s: %s", field.name, description)
+			}
+			require.Equal(t, "date", properties["date"].(map[string]any)["format"])
+			partySize := properties["party_size"].(map[string]any)
+			require.EqualValues(t, 1, partySize["minimum"])
+			require.EqualValues(t, 8, partySize["maximum"])
+			require.ElementsMatch(t, []string{"name", "date", "party_size", "seating"}, tool.InputSchema["required"])
+			require.ElementsMatch(t, []string{"dining_room", "terrace", "booth"}, properties["seating"].(map[string]any)["enum"])
+			require.Equal(t, test.title, tool.Source.PageTitle)
+			require.Positive(t, tool.Source.TabId)
+			require.Positive(t, tool.Source.WindowId)
+			if test.frame {
+				require.NotNil(t, tool.Source.Frame)
+				require.Positive(t, tool.Source.Frame.FrameId)
+				require.Equal(t, "file:///tmp/reservation.html", tool.Source.Frame.Url)
+			} else {
+				require.Nil(t, tool.Source.Frame)
+			}
+			require.NotNil(t, tool.Annotations)
+			require.True(t, tool.Annotations.Autosubmit)
+
+			timeout := 10
+			rsp, err := client.InvokeWebMCPToolWithResponse(ctx, instanceoapi.WebMCPInvokeRequest{
+				ToolRef:    tool.ToolRef,
+				Input:      map[string]any{"name": "Test Guest", "date": "2030-06-15", "party_size": 4, "seating": "terrace"},
+				TimeoutSec: &timeout,
+			})
+			require.NoError(t, err)
+			t.Logf("POST /webmcp/invoke: %s", rsp.Body)
+			require.Equal(t, http.StatusOK, rsp.StatusCode(), "%s", rsp.Body)
+			require.NotNil(t, rsp.JSON200)
+			require.Equal(t, instanceoapi.WebMCPInvocationResultStatusCompleted, rsp.JSON200.Status)
+			require.NotEmpty(t, rsp.JSON200.InvocationId)
+			require.Nil(t, rsp.JSON200.ErrorText)
+			values := map[string]any{"name": "Test Guest", "date": "2030-06-15", "party_size": "4", "seating": "terrace"}
+			require.Equal(t, values, rsp.JSON200.Output)
+
+			var state struct {
+				Values       map[string]any `json:"values"`
+				Confirmation string         `json:"confirmation"`
+				AgentInvoked string         `json:"agentInvoked"`
+				Submissions  string         `json:"submissions"`
+				Visible      bool           `json:"visible"`
+			}
+			executeWebMCPPlaywright(t, ctx, client, `
+				const frame = page.frames().find(frame => frame.url() === 'file:///tmp/reservation.html');
+				const state = await frame.evaluate(() => {
+					const confirmation = document.querySelector('#confirmation');
+					return {
+						values: Object.fromEntries(new FormData(document.querySelector('form'))),
+						confirmation: confirmation.textContent,
+						agentInvoked: confirmation.dataset.agentInvoked,
+						submissions: confirmation.dataset.submissions,
+					};
+				});
+				return { ...state, visible: await frame.locator('#confirmation').isVisible() };
+			`, &state)
+			require.Equal(t, values, state.Values)
+			require.Equal(t, "Reserved for Test Guest on 2030-06-15: 4 guests, terrace.", state.Confirmation)
+			require.Equal(t, "true", state.AgentInvoked)
+			require.Equal(t, "1", state.Submissions)
+			require.True(t, state.Visible)
+		})
+	}
+}
+
+func executeWebMCPPlaywright(t *testing.T, ctx context.Context, client *instanceoapi.ClientWithResponses, code string, result any) {
+	t.Helper()
+	rsp, err := client.ExecutePlaywrightCodeWithResponse(ctx, instanceoapi.ExecutePlaywrightCodeJSONRequestBody{Code: code})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode(), "%s", rsp.Body)
+	require.NotNil(t, rsp.JSON200)
+	require.True(t, rsp.JSON200.Success, "%s", rsp.Body)
+	data, err := json.Marshal(rsp.JSON200.Result)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, result))
+}

--- a/server/e2e/e2e_webmcp_test.go
+++ b/server/e2e/e2e_webmcp_test.go
@@ -16,19 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWebMCPDeclarative(t *testing.T) {
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
-	defer cancel()
-
-	c := NewTestContainer(t, headlessImage)
-	require.NoError(t, c.Start(ctx, ContainerConfig{}))
-	defer c.Stop(ctx)
-	require.NoError(t, c.WaitReady(ctx))
-
-	client, err := c.APIClient()
-	require.NoError(t, err)
+func testWebMCPDeclarative(t *testing.T, ctx context.Context, client *instanceoapi.ClientWithResponses) {
+	t.Helper()
 
 	// Like the audio fixture, use file:// inside the instance to provide a secure
 	// context without external URLs or a Docker-only host-loopback bridge.

--- a/server/e2e/testdata/webmcp/README.md
+++ b/server/e2e/testdata/webmcp/README.md
@@ -1,0 +1,16 @@
+# Declarative WebMCP fixtures
+
+`reservation.html` uses native form annotations from the [Chrome declarative API](https://developer.chrome.com/docs/ai/webmcp/declarative-api), modeled on the [Chrome Labs french-bistro demo](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/demos/french-bistro). Unlike the demo's manual-submit form, it sets `toolautosubmit` so invocation fills and submits the form. The submit handler updates a visible confirmation and returns the form data through `SubmitEvent.respondWith`. There is no imperative registration, polyfill, or external dependency.
+
+`embedded.html` embeds the same form to exercise frame discovery, provenance, and invocation. Like the audio e2e fixture, both pages are uploaded into the instance and loaded over `file://`, avoiding external URLs and a host-access dependency.
+
+Run from the repository root with Docker running:
+
+```sh
+DOCKER_BUILDKIT=1 docker build -f images/chromium-headless/image/Dockerfile -t kernel-headless-test .
+cd server
+E2E_CHROMIUM_HEADLESS_IMAGE=kernel-headless-test \
+  GOFLAGS='-run=TestWebMCPDeclarative -count=1' make test-e2e
+```
+
+Chromium 152.0.7977.42 with the image's default WebMCP flags exposes `reserve_table` with string name/date fields, a numeric party size with bounds, and a seating enum. It adds a date format hint to the field description. Both top-level and embedded invocations return `completed` and the submitted values; the tests also read the DOM through `/playwright/execute` to verify native agent submission occurred exactly once. Discovery and invocation responses are logged by the test. Missing declarative tools fail the test rather than silently skipping supported behavior.

--- a/server/e2e/testdata/webmcp/README.md
+++ b/server/e2e/testdata/webmcp/README.md
@@ -2,7 +2,7 @@
 
 `reservation.html` uses native form annotations from the [Chrome declarative API](https://developer.chrome.com/docs/ai/webmcp/declarative-api), modeled on the [Chrome Labs french-bistro demo](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/demos/french-bistro). Unlike the demo's manual-submit form, it sets `toolautosubmit` so invocation fills and submits the form. The submit handler updates a visible confirmation and returns the form data through `SubmitEvent.respondWith`. There is no imperative registration, polyfill, or external dependency.
 
-`embedded.html` embeds the same form to exercise frame discovery, provenance, and invocation. Like the audio e2e fixture, both pages are uploaded into the instance and loaded over `file://`, avoiding external URLs and a host-access dependency.
+`embedded.html` embeds the same form to exercise frame discovery, provenance, and invocation. Like the audio e2e fixture, both pages are uploaded into the instance and loaded over `file://`, avoiding external URLs and a host-access dependency. The declarative subtests reuse `TestPlaywrightExecuteAPI`'s container and warm Playwright daemon.
 
 Run from the repository root with Docker running:
 
@@ -10,7 +10,7 @@ Run from the repository root with Docker running:
 DOCKER_BUILDKIT=1 docker build -f images/chromium-headless/image/Dockerfile -t kernel-headless-test .
 cd server
 E2E_CHROMIUM_HEADLESS_IMAGE=kernel-headless-test \
-  GOFLAGS='-run=TestWebMCPDeclarative -count=1' make test-e2e
+  GOFLAGS='-run=TestPlaywrightExecuteAPI/WebMCPDeclarative -count=1' make test-e2e
 ```
 
 Chromium 152.0.7977.42 with the image's default WebMCP flags exposes `reserve_table` with string name/date fields, a numeric party size with bounds, and a seating enum. It adds a date format hint to the field description. Both top-level and embedded invocations return `completed` and the submitted values; the tests also read the DOM through `/playwright/execute` to verify native agent submission occurred exactly once. Discovery and invocation responses are logged by the test. Missing declarative tools fail the test rather than silently skipping supported behavior.

--- a/server/e2e/testdata/webmcp/embedded.html
+++ b/server/e2e/testdata/webmcp/embedded.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Embedded declarative reservation</title>
+</head>
+<body>
+  <h1>Embedded reservation form</h1>
+  <iframe title="Reservation" src="reservation.html" width="800" height="600"></iframe>
+</body>
+</html>

--- a/server/e2e/testdata/webmcp/reservation.html
+++ b/server/e2e/testdata/webmcp/reservation.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Declarative reservation</title>
+</head>
+<body>
+  <h1>Table reservation</h1>
+  <!-- Mirrors the Chrome Labs french-bistro declarative demo, with autosubmit:
+       https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/demos/french-bistro
+       Native HTML annotations only; no imperative registration or polyfill. -->
+  <form toolname="reserve_table" tooldescription="Reserve a table with guest details and seating preferences." toolautosubmit>
+    <label for="name">Guest name</label>
+    <input id="name" name="name" type="text" required toolparamdescription="Name for the reservation">
+
+    <label for="date">Reservation date</label>
+    <input id="date" name="date" type="date" required toolparamdescription="Date of the reservation">
+
+    <label for="party_size">Party size</label>
+    <input id="party_size" name="party_size" type="number" min="1" max="8" required toolparamdescription="Number of guests">
+
+    <label for="seating">Seating preference</label>
+    <select id="seating" name="seating" required toolparamdescription="Preferred seating area">
+      <option value="dining_room">Dining room</option>
+      <option value="terrace">Outdoor terrace</option>
+      <option value="booth">Private booth</option>
+    </select>
+
+    <button type="submit">Reserve table</button>
+  </form>
+  <p id="confirmation" role="status" aria-live="polite">No reservation submitted.</p>
+  <script>
+    document.querySelector('form').addEventListener('submit', (event) => {
+      event.preventDefault();
+      const reservation = Object.fromEntries(new FormData(event.target));
+      const confirmation = document.querySelector('#confirmation');
+      confirmation.textContent = `Reserved for ${reservation.name} on ${reservation.date}: ${reservation.party_size} guests, ${reservation.seating}.`;
+      confirmation.dataset.agentInvoked = String(event.agentInvoked);
+      confirmation.dataset.submissions = String(Number(confirmation.dataset.submissions || 0) + 1);
+      if (event.agentInvoked) {
+        event.respondWith(Promise.resolve(reservation));
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add a self-contained reservation form using native declarative WebMCP annotations, `toolautosubmit`, and `SubmitEvent.respondWith`; no imperative registration or polyfill.
- Reuse `TestPlaywrightExecuteAPI`'s container and warm daemon rather than adding another container startup. Exercise `GET /webmcp/tools` and `POST /webmcp/invoke` for both a top-level form and an embedded frame. Assert synthesized schema, field descriptions, required fields, numeric bounds, select enum, autosubmit annotation, and page/frame provenance.
- Read the DOM through `/playwright/execute` to verify the field values, visible confirmation, `agentInvoked`, and exactly one submission. Include fixture documentation and local run commands.

## Browser results

The locally built headless image runs Chromium 152.0.7977.42 with its default WebMCP flags. Both variants expose `reserve_table` with string name/date fields, numeric party size, and seating enum `["dining_room", "terrace", "booth"]`. Chromium adds `format: "date"` and a date-format description hint. Top-level provenance has `frame: null`; embedded provenance identifies the reservation frame and retains the parent page title/URL.

Both invocations return `status: "completed"` and output:

```json
{"date":"2030-06-15","name":"Test Guest","party_size":"4","seating":"terrace"}
```

The visible confirmation contains these values and records one native agent submission. Declarative synthesis works, so there is no unsupported-browser skip.

## Validation

- Built the headless image using the documented Dockerfile.
- Passed `make test-e2e` with `GOFLAGS='-run=TestPlaywrightExecuteAPI$ -count=3'` against that image, including race detection. Used `TESTCONTAINERS_HOST_OVERRIDE=127.0.0.1` because local `localhost` resolution was unavailable.
- Passed `make test-runtime` (14 tests).
- Passed `go test -race ./lib/webmcpclient ./lib/browsersurface ./cmd/api/api ./lib/oapi`.
- `make test-unit` passed vet and all packages except the existing `TestUpstreamManagerDetectsChromiumAndRestart`: Chromium's temporary profile cleanup fails with `directory not empty`, including on retry. No unrelated production code changed.
- Did not run the entire e2e suite or build the headful image.
