### PR TITLE
Bump S2 Go SDK to v0.22.1

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/m1k1o/neko/server v0.0.0-20251008185748-46e2fc7d3866
 	github.com/nrednav/cuid2 v1.1.0
 	github.com/oapi-codegen/runtime v1.2.0
-	github.com/s2-streamstore/s2-sdk-go v0.16.1
+	github.com/s2-streamstore/s2-sdk-go v0.22.1
 	github.com/samber/lo v1.52.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -427,8 +427,8 @@ github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3V
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/s2-streamstore/s2-sdk-go v0.16.1 h1:18Qht850wUhIb9JZkMwF5EJWfnmZnjdtW3z8xOuL7Ys=
-github.com/s2-streamstore/s2-sdk-go v0.16.1/go.mod h1:1a+v2sGqU+s5neI8XwqRJz78ktStkR+mZH/JEi9HNSo=
+github.com/s2-streamstore/s2-sdk-go v0.22.1 h1:KDFOwkQKdIs+63xT6xcIirn/ramEUQ4wEUsMlGzQDfk=
+github.com/s2-streamstore/s2-sdk-go v0.22.1/go.mod h1:1a+v2sGqU+s5neI8XwqRJz78ktStkR+mZH/JEi9HNSo=
 github.com/sagikazarmark/locafero v0.10.0 h1:FM8Cv6j2KqIhM2ZK7HZjm4mpj9NBktLgowT1aN9q5Cc=
 github.com/sagikazarmark/locafero v0.10.0/go.mod h1:Ieo3EUsjifvQu4NZwV5sPd4dwvu0OCgEQV7vjc9yDjw=
 github.com/samber/lo v1.52.0 h1:Rvi+3BFHES3A8meP33VPAxiBZX/Aws5RxrschYGjomw=


### PR DESCRIPTION
## summary

- bump the S2 Go SDK from v0.16.1 to v0.22.1
- pick up server-advised reconnect handling for telemetry append sessions

## testing

CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrading a telemetry/storage client across several minor versions can change reconnect and session behavior in production without any local code review in the diff.
> 
> **Overview**
> **Bumps** `github.com/s2-streamstore/s2-sdk-go` from **v0.16.1** to **v0.22.1** in `server/go.mod` and refreshes `server/go.sum`. There are no application code changes in this PR.
> 
> The upgrade is intended to pick up **server-advised reconnect handling** for S2 **append sessions** used when telemetry/events are written (e.g. via `newS2Storage` / `AppendSession` in `server/lib/events/s2storage.go`). Behavior at the call sites should stay the same; resilience during disconnects is expected to improve inside the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 493c4f684293232454f8746d122124058e47203e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->