### PR TITLE
Suppress search choice and extension debugger warnings

### DIFF
--- a/images/chromium-headful/run-docker.sh
+++ b/images/chromium-headful/run-docker.sh
@@ -14,7 +14,7 @@ mkdir -p "$HOST_RECORDINGS_DIR"
 RUN_AS_ROOT="${RUN_AS_ROOT:-false}"
 
 # Build Chromium flags file and mount
-CHROMIUM_FLAGS_DEFAULT="--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --enable-features=WebMCPTesting,DevToolsWebMCPSupport"
+CHROMIUM_FLAGS_DEFAULT="--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --enable-features=WebMCPTesting,DevToolsWebMCPSupport --disable-search-engine-choice-screen --silent-debugger-extension-api"
 if [[ "$RUN_AS_ROOT" == "true" ]]; then
   CHROMIUM_FLAGS_DEFAULT="$CHROMIUM_FLAGS_DEFAULT --no-sandbox --no-zygote"
 fi

--- a/images/chromium-headful/run-unikernel.sh
+++ b/images/chromium-headful/run-unikernel.sh
@@ -20,7 +20,7 @@ volume_name="${NAME}-flags"
 # RUN_AS_ROOT defaults to true in unikernel (for now, until we figure it out)
 RUN_AS_ROOT="${RUN_AS_ROOT:-true}"
 
-chromium_flags_default="--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --enable-features=WebMCPTesting,DevToolsWebMCPSupport"
+chromium_flags_default="--user-data-dir=/home/kernel/user-data --disable-dev-shm-usage --disable-gpu --start-maximized --disable-software-rasterizer --remote-allow-origins=* --enable-features=WebMCPTesting,DevToolsWebMCPSupport --disable-search-engine-choice-screen --silent-debugger-extension-api"
 if [[ "$RUN_AS_ROOT" == "true" ]]; then
   chromium_flags_default="$chromium_flags_default --no-sandbox --no-zygote"
 fi

--- a/server/cmd/wrapper/chromium.go
+++ b/server/cmd/wrapper/chromium.go
@@ -58,6 +58,7 @@ func applyHeadlessDefaultFlags() {
 		"--no-service-autorun",
 		"--ozone-platform=headless",
 		"--password-store=basic",
+		"--silent-debugger-extension-api",
 		"--unsafely-disable-devtools-self-xss-warnings",
 		"--use-angle=swiftshader",
 		"--use-gl=angle",

--- a/server/cmd/wrapper/chromium_test.go
+++ b/server/cmd/wrapper/chromium_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestApplyHeadlessDefaultFlags(t *testing.T) {
+	t.Setenv("CHROMIUM_FLAGS", "")
+	applyHeadlessDefaultFlags()
+	flags := strings.Fields(os.Getenv("CHROMIUM_FLAGS"))
+	for _, flag := range []string{"--disable-search-engine-choice-screen", "--silent-debugger-extension-api"} {
+		if !slices.Contains(flags, flag) {
+			t.Errorf("default flags missing %s", flag)
+		}
+	}
+}
+
+func TestApplyHeadlessDefaultFlagsPreservesOverride(t *testing.T) {
+	const flags = "--headless --no-sandbox"
+	t.Setenv("CHROMIUM_FLAGS", flags)
+	applyHeadlessDefaultFlags()
+	if got := os.Getenv("CHROMIUM_FLAGS"); got != flags {
+		t.Errorf("CHROMIUM_FLAGS = %q, want %q", got, flags)
+	}
+}


### PR DESCRIPTION
## Summary
Add silent debugger mode to headless defaults (search-choice suppression is already present). Enable both flags in headful Docker and Unikraft launch-script defaults. Explicit CHROMIUM_FLAGS overrides remain unchanged.

Suppresses setup and debugger warning UI without changing the search provider or granting permissions. Baked defaults require an image release.

## Tests
Passed: GOCACHE=/tmp/go-build go test ./cmd/wrapper
Passed: bash -n images/chromium-headful/run-{docker,unikernel}.sh
Full image build and browser end-to-end tests not run.