### PR TITLE
Enable WebMCP explicitly in declarative e2e test

### DIFF
--- a/server/e2e/e2e_playwright_test.go
+++ b/server/e2e/e2e_playwright_test.go
@@ -25,7 +25,11 @@ func TestPlaywrightExecuteAPI(t *testing.T) {
 	defer cancel()
 
 	c := NewTestContainer(t, headlessImage)
-	require.NoError(t, c.Start(ctx, ContainerConfig{}), "failed to start container")
+	require.NoError(t, c.Start(ctx, ContainerConfig{
+		Env: map[string]string{
+			"CHROMIUM_FLAGS": "--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
+		},
+	}), "failed to start container")
 	defer c.Stop(ctx)
 
 	require.NoError(t, c.WaitReady(ctx), "api not ready")


### PR DESCRIPTION
## Summary

- explicitly enable the WebMCP runtime and DevTools features for the declarative WebMCP e2e test
- avoid relying on browser field-trial defaults that vary between Chromium builds

## Why

The Docker e2e backend supplies `CHROMIUM_FLAGS`, so the image's default flag set is not applied. The declarative test happened to pass when the browser's testing field-trial configuration enabled WebMCP, but returned an empty tool list in builds without that configuration.

## Testing

- `TESTCONTAINERS_HOST_OVERRIDE=127.0.0.1 E2E_CHROMIUM_HEADLESS_IMAGE=<affected-image> go test -v -count=1 -timeout 15m -run '^TestPlaywrightExecuteAPI$' ./e2e`
  - top-level declarative discovery and invocation pass
  - embedded declarative discovery and invocation pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only container env change; no production runtime or auth/data paths affected.
> 
> **Overview**
> **`TestPlaywrightExecuteAPI`** now starts its Docker test container with explicit **`CHROMIUM_FLAGS`** (`WebMCPTesting` and `DevToolsWebMCPSupport`) instead of an empty **`ContainerConfig`**.
> 
> Because the e2e backend applies supplied **`CHROMIUM_FLAGS`** in place of the image defaults, WebMCP-dependent checks (including the nested **`WebMCPDeclarative`** flow) no longer depend on Chromium field-trial defaults that differ across builds—avoiding flaky empty tool lists on some images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a64d438ff00d9744fbb5ce49c29e3d432de66f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->