### PR TITLE
Pin Bun setup action

### DIFF
--- a/.github/workflows/live-view-test.yaml
+++ b/.github/workflows/live-view-test.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Run unit tests
         run: bun test tests


### PR DESCRIPTION
## Summary

- pin the third-party Bun setup action to the commit currently referenced by v2.2.0
- retain the version comment for future updates

## Testing

- `bun test tests` from `images/chromium-headful/client`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pinning with no application or runtime logic changes.
> 
> **Overview**
> Pins the **Test Live View client** workflow’s Bun setup step from the floating `oven-sh/setup-bun@v2` tag to commit `0c5077e51419868618aeaa5fe8019c62421857d6`, with an inline `# v2.2.0` comment so upgrades stay traceable.
> 
> Behavior of the job is unchanged: it still installs Bun before `bun test tests` in `images/chromium-headful/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0143ca154f673d289d2f3f29f0aebd5c6a7e487d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->